### PR TITLE
feat: pastel design system with Phosphor Icons

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,229 @@
+# NestSync Design System
+
+## Brand Identity
+
+**Product:** NestSync — shared household management app for roommates and families.
+**Personality:** Warm, approachable, cozy, organized.
+
+---
+
+## Color Palette
+
+Based on ColorHunt Palette 2 (`#D97D55`, `#F4E9D7`, `#B8C4A9`, `#6FA4AF`) with Palette 1's gold (`#E9B63B`) as a secondary accent.
+
+### Core Colors
+
+| Name       | Hex       | Role                                          |
+| ---------- | --------- | --------------------------------------------- |
+| Teal       | `#6FA4AF` | Primary — buttons, links, active states       |
+| Cream      | `#F4E9D7` | Background — page backgrounds                 |
+| Sage       | `#B8C4A9` | Secondary surface — cards, subtle backgrounds  |
+| Terracotta | `#D97D55` | Warm highlight — accents, emphasis             |
+| Gold       | `#E9B63B` | Secondary accent — points, stars, gamification |
+
+### Semantic Tokens
+
+| Token                | Value       | Usage                                |
+| -------------------- | ----------- | ------------------------------------ |
+| `--color-primary`    | `#6FA4AF`   | Primary actions, buttons, focus      |
+| `--color-primary-hover` | `#5B8F9A` | Hover state for primary elements     |
+| `--color-primary-light` | `#6FA4AF1A` | Primary tinted backgrounds (10%)   |
+| `--color-primary-medium` | `#6FA4AF33` | Primary medium backgrounds (20%) |
+| `--color-accent`     | `#E9B63B`   | Points, stars, trophies              |
+| `--color-accent-light` | `#E9B63B1A` | Accent tinted backgrounds (10%)   |
+| `--color-highlight`  | `#D97D55`   | Warm emphasis, terracotta accents    |
+| `--color-highlight-light` | `#D97D551A` | Highlight tinted backgrounds     |
+| `--color-background` | `#F4E9D7`   | Page background                      |
+| `--color-surface`    | `#FFFFFF`   | Cards, modals, sidebar               |
+| `--color-surface-secondary` | `#B8C4A926` | Subtle card-like areas (15%)  |
+| `--color-text-primary` | `#1E293B` | Headings, primary body text          |
+| `--color-text-secondary` | `#64748B` | Secondary labels, descriptions     |
+| `--color-text-muted` | `#94A3B8`   | Timestamps, hints, placeholders      |
+| `--color-text-on-primary` | `#FFFFFF` | Text on primary-colored buttons   |
+| `--color-border`     | `#D1D5DB`   | Standard borders                     |
+| `--color-border-light` | `#E5E7EB` | Subtle borders, dividers             |
+| `--color-error`      | `#DC2626`   | Error states, overdue items          |
+| `--color-error-light` | `#FEF2F2`  | Error background                     |
+| `--color-error-text` | `#B91C1C`   | Error message text                   |
+| `--color-success`    | `#16A34A`   | Success states, completion           |
+| `--color-success-light` | `#F0FDF4` | Success background                  |
+| `--color-success-text` | `#15803D`  | Success message text                 |
+
+### Status Colors
+
+Standard red/green are retained for error/success to ensure accessibility for color-blind users. Terracotta is used for warm highlights, **not** as an error replacement.
+
+---
+
+## Typography
+
+All fonts loaded via `next/font/google` for optimal performance.
+
+### Font Stack
+
+| Role     | Font Family | Weights        | Usage                           |
+| -------- | ----------- | -------------- | ------------------------------- |
+| Headings | **Nunito**  | 600, 700, 800  | Page titles, section headings   |
+| Body     | **Inter**   | 400, 500, 600  | Body text, labels, UI elements  |
+| Logo     | **Satisfy** | 400            | Logo wordmark only              |
+
+### Type Scale
+
+| Element        | Font    | Size   | Weight | Line Height |
+| -------------- | ------- | ------ | ------ | ----------- |
+| Page title     | Nunito  | 24–28px | 800   | 1.2         |
+| Section heading | Nunito | 20px   | 700    | 1.3         |
+| Card title     | Nunito  | 16px   | 700    | 1.4         |
+| Body           | Inter   | 14–15px | 400   | 1.6         |
+| Label          | Inter   | 13px   | 500    | 1.4         |
+| Caption/Small  | Inter   | 12px   | 400    | 1.5         |
+| Badge          | Inter   | 11–12px | 600   | 1.0         |
+
+### Why These Fonts
+
+- **Nunito** — rounded terminals give warmth that matches the pastel palette; friendly and approachable for a household app.
+- **Inter** — industry-standard UI readability; clean contrast against Nunito's softness.
+- **Satisfy** — flowing cursive that reads as personal and handwritten; used exclusively for the logo wordmark.
+
+---
+
+## Logo
+
+### Primary Logo (Wordmark)
+
+The NestSync logo is a **text-only wordmark** using the Satisfy font in teal (`#6FA4AF`).
+
+```
+NestSync    (Satisfy, cursive, #6FA4AF)
+```
+
+### Variants
+
+| Variant       | Text Color | Background   | Usage                        |
+| ------------- | ---------- | ------------ | ---------------------------- |
+| Teal on white | `#6FA4AF`  | White        | Primary — headers, cards     |
+| Teal on cream | `#6FA4AF`  | `#F4E9D7`   | On brand background          |
+| Cream on dark | `#F4E9D7`  | `#1E293B`   | Dark backgrounds, footer     |
+| Dark on white | `#1E293B`  | White        | Monochrome/print usage       |
+
+### Favicon / App Icon
+
+The favicon is an **"N" lettermark** — the letter "N" in Satisfy font, white on a teal rounded square.
+
+- Background: `#6FA4AF` with `border-radius: ~22%`
+- Letter: White, Satisfy font, centered
+- Sizes: 16px, 32px, 48px, 180px (apple-touch-icon), 512px (PWA)
+
+### Logo Clear Space
+
+Maintain minimum clear space equal to the cap-height of the "N" on all sides.
+
+### Logo Don'ts
+
+- Do not stretch or distort
+- Do not change the font
+- Do not add effects (shadows, outlines, gradients)
+- Do not use colors outside the approved palette
+- Do not place on busy/patterned backgrounds without sufficient contrast
+
+---
+
+## Icon Library
+
+**Library:** [Phosphor Icons](https://phosphoricons.com/) via `@phosphor-icons/react`
+**Default weight:** Regular (matches stroke-based aesthetic)
+**Replaces:** lucide-react
+
+### Icon Mapping
+
+| Purpose         | Icon Name         | Context                    |
+| --------------- | ----------------- | -------------------------- |
+| Home/Dashboard  | `House`           | Navigation, landing        |
+| Chores          | `ClipboardText`   | Chore lists, boards        |
+| Calendar/Date   | `CalendarBlank`   | Due dates                  |
+| Points/Star     | `Star`            | Gamification, ratings      |
+| Trophy          | `Trophy`          | Weekly stats, leaderboard  |
+| User            | `User`            | Assigned member            |
+| Add user        | `UserPlus`        | Onboarding                 |
+| Add/Create      | `Plus`            | Create buttons             |
+| Check           | `Check`           | Confirmation               |
+| Complete        | `CheckCircle`     | Task completion            |
+| Loading         | `SpinnerGap`      | Loading states             |
+| Copy            | `Copy`            | Clipboard copy             |
+| Delete          | `Trash`           | Remove items               |
+| Repeat/Recur    | `ArrowsClockwise` | Recurring chores           |
+| Sign out        | `SignOut`          | Logout                     |
+| Menu            | `List`            | Mobile hamburger           |
+| Close           | `X`               | Close/dismiss              |
+| Arrow right     | `ArrowRight`      | Navigation, CTAs           |
+| Money           | `CurrencyDollar`  | Expenses (future)          |
+| Announce        | `Megaphone`       | Announcements              |
+| Vote            | `Scales`          | Democratic governance       |
+
+---
+
+## Component Patterns
+
+### Cards
+
+```
+Background:  bg-surface (white)
+Border:      border-border-light (#E5E7EB)
+Radius:      rounded-xl (12px)
+Padding:     p-4 or p-5
+Shadow:      none by default, hover:shadow-sm
+```
+
+### Buttons
+
+**Primary:**
+```
+Background:  bg-primary (#6FA4AF)
+Hover:       bg-primary-hover (#5B8F9A)
+Text:        text-text-on-primary (white)
+Radius:      rounded-xl
+Font:        Inter 600
+```
+
+**Secondary/Outline:**
+```
+Background:  transparent
+Border:      border-primary
+Text:        text-primary
+Hover:       bg-primary-light
+```
+
+### Badges
+
+```
+Points:      bg-accent-light, text-accent
+Status:      bg-primary-light, text-primary
+Error:       bg-error-light, text-error-text
+Success:     bg-success-light, text-success-text
+```
+
+### Active Navigation
+
+```
+Active:      bg-primary-light, text-primary-hover
+Inactive:    text-text-secondary, hover:bg-surface-secondary
+```
+
+---
+
+## Spacing & Layout
+
+- Page padding: `px-4 lg:px-6`
+- Card gap: `gap-4`
+- Section gap: `space-y-6`
+- Max content width: Fluid within sidebar layout
+
+---
+
+## Accessibility
+
+- All interactive elements meet WCAA AA contrast ratios
+- Error/success states use red/green (standard semantic colors)
+- Icons always paired with text labels or `aria-label`
+- Focus rings use `ring-primary`
+- No color-only indicators — always paired with text or icons

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "nestsync-app",
       "version": "0.1.0",
       "dependencies": {
+        "@phosphor-icons/react": "^2.1.10",
         "@prisma/client": "^5.22.0",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.98.0",
         "@tanstack/react-query": "^5.90.21",
-        "lucide-react": "^0.577.0",
         "next": "^16.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -2089,6 +2089,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@playwright/test": {
@@ -7312,15 +7325,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.10",
     "@prisma/client": "^5.22.0",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",
     "@tanstack/react-query": "^5.90.21",
-    "lucide-react": "^0.577.0",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/src/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -18,7 +18,7 @@ export function ForgotPasswordForm() {
     <div className="space-y-6">
       {state.success ? (
         <div
-          className="p-4 rounded-lg bg-green-50 text-green-700 text-sm space-y-2"
+          className="p-4 rounded-lg bg-success-light text-success-text text-sm space-y-2"
           role="status"
         >
           <p className="font-medium">Check your email</p>
@@ -31,7 +31,7 @@ export function ForgotPasswordForm() {
         <form action={formAction} className="space-y-4" noValidate>
           {state.error && (
             <div
-              className="p-3 rounded-lg bg-red-50 text-red-700 text-sm"
+              className="p-3 rounded-lg bg-error-light text-error-text text-sm"
               role="alert"
             >
               {state.error}
@@ -52,10 +52,10 @@ export function ForgotPasswordForm() {
         </form>
       )}
 
-      <p className="text-center text-sm text-slate-500">
+      <p className="text-center text-sm text-text-secondary">
         <Link
           href="/login"
-          className="text-indigo-600 font-medium hover:text-indigo-700"
+          className="text-primary font-medium hover:text-primary-hover"
         >
           Back to sign in
         </Link>

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -16,13 +16,13 @@ export default async function ForgotPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-sm space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-slate-900">
+          <h1 className="text-2xl font-bold font-heading text-text-primary">
             Reset your password
           </h1>
-          <p className="text-slate-500">
+          <p className="text-text-secondary">
             Enter your email and we&apos;ll send you a reset link
           </p>
         </div>

--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -25,7 +25,7 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
       <form action={formAction} className="space-y-4" noValidate>
         {state.error && (
           <div
-            className="p-3 rounded-lg bg-red-50 text-red-700 text-sm"
+            className="p-3 rounded-lg bg-error-light text-error-text text-sm"
             role="alert"
           >
             {state.error}
@@ -54,7 +54,7 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
         <div className="flex justify-end">
           <Link
             href="/forgot-password"
-            className="text-sm text-indigo-600 hover:text-indigo-700"
+            className="text-sm text-primary hover:text-primary-hover"
           >
             Forgot password?
           </Link>
@@ -63,11 +63,11 @@ export function LoginForm({ redirectTo }: { redirectTo?: string }) {
         <SubmitButton>Sign in</SubmitButton>
       </form>
 
-      <p className="text-center text-sm text-slate-500">
+      <p className="text-center text-sm text-text-secondary">
         Don&apos;t have an account?{" "}
         <Link
           href="/signup"
-          className="text-indigo-600 font-medium hover:text-indigo-700"
+          className="text-primary font-medium hover:text-primary-hover"
         >
           Sign up
         </Link>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -22,16 +22,16 @@ export default async function LoginPage({
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-sm space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-slate-900">Welcome back</h1>
-          <p className="text-slate-500">Sign in to your NestSync account</p>
+          <h1 className="text-2xl font-bold font-heading text-text-primary">Welcome back</h1>
+          <p className="text-text-secondary">Sign in to your NestSync account</p>
         </div>
 
         {params.message && (
           <div
-            className="p-3 rounded-lg bg-green-50 text-green-700 text-sm"
+            className="p-3 rounded-lg bg-success-light text-success-text text-sm"
             role="status"
           >
             {params.message}

--- a/src/app/(auth)/onboarding/create/create-household-form.tsx
+++ b/src/app/(auth)/onboarding/create/create-household-form.tsx
@@ -47,7 +47,7 @@ export function CreateHouseholdForm() {
     <form action={formAction} className="space-y-4" noValidate>
       {state.error && (
         <div
-          className="p-3 rounded-lg bg-red-50 text-red-700 text-sm"
+          className="p-3 rounded-lg bg-error-light text-error-text text-sm"
           role="alert"
         >
           {state.error}
@@ -66,7 +66,7 @@ export function CreateHouseholdForm() {
       <div className="space-y-1.5">
         <label
           htmlFor="household-timezone"
-          className="block text-sm font-medium text-slate-700"
+          className="block text-sm font-medium text-text-primary"
         >
           Timezone
         </label>
@@ -74,7 +74,7 @@ export function CreateHouseholdForm() {
           id="household-timezone"
           name="timezone"
           defaultValue={detectedTimezone}
-          className="w-full px-3 py-2.5 rounded-lg border border-slate-300 text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow bg-white"
+          className="w-full px-3 py-2.5 rounded-lg border border-border text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-shadow bg-surface"
         >
           {COMMON_TIMEZONES.map((tz) => (
             <option key={tz} value={tz}>
@@ -92,10 +92,10 @@ export function CreateHouseholdForm() {
 
       <SubmitButton>Create household</SubmitButton>
 
-      <p className="text-center text-sm text-slate-500">
+      <p className="text-center text-sm text-text-secondary">
         <Link
           href="/onboarding"
-          className="text-indigo-600 font-medium hover:text-indigo-700"
+          className="text-primary font-medium hover:text-primary-hover"
         >
           Back to options
         </Link>

--- a/src/app/(auth)/onboarding/create/page.tsx
+++ b/src/app/(auth)/onboarding/create/page.tsx
@@ -26,13 +26,13 @@ export default async function CreateHouseholdPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-sm space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-slate-900">
+          <h1 className="text-2xl font-bold font-heading text-text-primary">
             Create a household
           </h1>
-          <p className="text-slate-500">
+          <p className="text-text-secondary">
             Set up your shared living space
           </p>
         </div>

--- a/src/app/(auth)/onboarding/join/join-household-form.tsx
+++ b/src/app/(auth)/onboarding/join/join-household-form.tsx
@@ -18,7 +18,7 @@ export function JoinHouseholdForm() {
     <form action={formAction} className="space-y-4" noValidate>
       {state.error && (
         <div
-          className="p-3 rounded-lg bg-red-50 text-red-700 text-sm"
+          className="p-3 rounded-lg bg-error-light text-error-text text-sm"
           role="alert"
         >
           {state.error}
@@ -37,10 +37,10 @@ export function JoinHouseholdForm() {
 
       <SubmitButton>Join household</SubmitButton>
 
-      <p className="text-center text-sm text-slate-500">
+      <p className="text-center text-sm text-text-secondary">
         <Link
           href="/onboarding"
-          className="text-indigo-600 font-medium hover:text-indigo-700"
+          className="text-primary font-medium hover:text-primary-hover"
         >
           Back to options
         </Link>

--- a/src/app/(auth)/onboarding/join/page.tsx
+++ b/src/app/(auth)/onboarding/join/page.tsx
@@ -26,13 +26,13 @@ export default async function JoinHouseholdPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-sm space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-slate-900">
+          <h1 className="text-2xl font-bold font-heading text-text-primary">
             Join a household
           </h1>
-          <p className="text-slate-500">
+          <p className="text-text-secondary">
             Enter the invite code from your roommate
           </p>
         </div>

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
-import { Home, UserPlus } from "lucide-react";
+import { House, UserPlus } from "@phosphor-icons/react/dist/ssr";
 
 export default async function OnboardingPage({
   searchParams,
@@ -33,20 +33,20 @@ export default async function OnboardingPage({
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-md space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-slate-900">
+          <h1 className="text-2xl font-bold text-text-primary font-heading">
             Welcome to NestSync
           </h1>
-          <p className="text-slate-500">
+          <p className="text-text-secondary">
             Create a new household or join an existing one
           </p>
         </div>
 
         {params.error && (
           <div
-            className="p-3 rounded-lg bg-red-50 text-red-700 text-sm"
+            className="p-3 rounded-lg bg-error-light text-error-text text-sm"
             role="alert"
           >
             {params.error}
@@ -56,14 +56,14 @@ export default async function OnboardingPage({
         <div className="grid gap-4">
           <Link
             href="/onboarding/create"
-            className="flex items-center gap-4 p-5 bg-white rounded-xl border border-slate-200 hover:border-indigo-300 hover:shadow-md transition-all group"
+            className="flex items-center gap-4 p-5 bg-surface rounded-xl border border-border-light hover:border-primary hover:shadow-md transition-all group"
           >
-            <div className="flex-shrink-0 w-12 h-12 bg-indigo-50 rounded-lg flex items-center justify-center group-hover:bg-indigo-100 transition-colors">
-              <Home className="w-6 h-6 text-indigo-600" />
+            <div className="flex-shrink-0 w-12 h-12 bg-primary-light rounded-lg flex items-center justify-center group-hover:bg-primary-medium transition-colors">
+              <House className="w-6 h-6 text-primary" />
             </div>
             <div>
-              <p className="font-semibold text-slate-900">Create a household</p>
-              <p className="text-sm text-slate-500">
+              <p className="font-semibold text-text-primary">Create a household</p>
+              <p className="text-sm text-text-secondary">
                 Start a new household and invite your roommates
               </p>
             </div>
@@ -71,14 +71,14 @@ export default async function OnboardingPage({
 
           <Link
             href="/onboarding/join"
-            className="flex items-center gap-4 p-5 bg-white rounded-xl border border-slate-200 hover:border-indigo-300 hover:shadow-md transition-all group"
+            className="flex items-center gap-4 p-5 bg-surface rounded-xl border border-border-light hover:border-primary hover:shadow-md transition-all group"
           >
-            <div className="flex-shrink-0 w-12 h-12 bg-emerald-50 rounded-lg flex items-center justify-center group-hover:bg-emerald-100 transition-colors">
-              <UserPlus className="w-6 h-6 text-emerald-600" />
+            <div className="flex-shrink-0 w-12 h-12 bg-highlight-light rounded-lg flex items-center justify-center group-hover:bg-highlight/20 transition-colors">
+              <UserPlus className="w-6 h-6 text-highlight" />
             </div>
             <div>
-              <p className="font-semibold text-slate-900">Join a household</p>
-              <p className="text-sm text-slate-500">
+              <p className="font-semibold text-text-primary">Join a household</p>
+              <p className="text-sm text-text-secondary">
                 Enter an invite code from your roommate
               </p>
             </div>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -2,13 +2,13 @@ import { ResetPasswordForm } from "./reset-password-form";
 
 export default function ResetPasswordPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-sm space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-slate-900">
+          <h1 className="text-2xl font-bold font-heading text-text-primary">
             Set new password
           </h1>
-          <p className="text-slate-500">
+          <p className="text-text-secondary">
             Enter your new password below
           </p>
         </div>

--- a/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -17,7 +17,7 @@ export function ResetPasswordForm() {
     <form action={formAction} className="space-y-4" noValidate>
       {state.error && (
         <div
-          className="p-3 rounded-lg bg-red-50 text-red-700 text-sm"
+          className="p-3 rounded-lg bg-error-light text-error-text text-sm"
           role="alert"
         >
           {state.error}

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -22,11 +22,11 @@ export default async function SignupPage({
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <div className="w-full max-w-sm space-y-6">
         <div className="text-center space-y-2">
-          <h1 className="text-2xl font-bold text-slate-900">Create an account</h1>
-          <p className="text-slate-500">Get started with NestSync</p>
+          <h1 className="text-2xl font-bold font-heading text-text-primary">Create an account</h1>
+          <p className="text-text-secondary">Get started with NestSync</p>
         </div>
 
         <SignupForm inviteCode={params.invite} />

--- a/src/app/(auth)/signup/signup-form.tsx
+++ b/src/app/(auth)/signup/signup-form.tsx
@@ -25,7 +25,7 @@ export function SignupForm({ inviteCode }: { inviteCode?: string }) {
     <div className="space-y-6">
       {code && (
         <div
-          className="p-3 rounded-lg bg-indigo-50 text-indigo-700 text-sm"
+          className="p-3 rounded-lg bg-primary-light text-primary-hover text-sm"
           role="status"
         >
           You&apos;ve been invited to a household! Create an account to join.
@@ -38,7 +38,7 @@ export function SignupForm({ inviteCode }: { inviteCode?: string }) {
       <form action={formAction} className="space-y-4" noValidate>
         {state.error && (
           <div
-            className="p-3 rounded-lg bg-red-50 text-red-700 text-sm"
+            className="p-3 rounded-lg bg-error-light text-error-text text-sm"
             role="alert"
           >
             {state.error}
@@ -76,11 +76,11 @@ export function SignupForm({ inviteCode }: { inviteCode?: string }) {
         <SubmitButton>Create account</SubmitButton>
       </form>
 
-      <p className="text-center text-sm text-slate-500">
+      <p className="text-center text-sm text-text-secondary">
         Already have an account?{" "}
         <Link
           href="/login"
-          className="text-indigo-600 font-medium hover:text-indigo-700"
+          className="text-primary font-medium hover:text-primary-hover"
         >
           Sign in
         </Link>

--- a/src/app/(dashboard)/dashboard/chores/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/chores/new/page.tsx
@@ -12,10 +12,10 @@ export default async function NewChorePage() {
   return (
     <div className="max-w-lg mx-auto space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">
+        <h1 className="text-2xl font-bold font-heading text-text-primary">
           Create a New Chore
         </h1>
-        <p className="text-sm text-slate-500 mt-1">
+        <p className="text-sm text-text-secondary mt-1">
           Set up a recurring or one-time chore for your household
         </p>
       </div>

--- a/src/app/(dashboard)/dashboard/chores/page.tsx
+++ b/src/app/(dashboard)/dashboard/chores/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { getCurrentMembership } from "@/lib/household/queries";
 import { getChoreInstances } from "@/lib/chores/queries";
 import { ChoreBoard } from "@/components/chores/chore-board";
-import { Plus } from "lucide-react";
+import { Plus } from "@phosphor-icons/react/dist/ssr";
 
 export default async function ChoresPage() {
   const membership = await getCurrentMembership();
@@ -17,21 +17,21 @@ export default async function ChoresPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900">Chore Board</h1>
-          <p className="text-sm text-slate-500 mt-1">
+          <h1 className="text-2xl font-bold text-text-primary font-heading">Chore Board</h1>
+          <p className="text-sm text-text-secondary mt-1">
             Manage and track household chores
           </p>
         </div>
         <div className="flex items-center gap-2">
           <Link
             href="/dashboard/chores/templates"
-            className="px-4 py-2.5 text-sm font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100 rounded-xl transition-colors"
+            className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-surface-secondary rounded-xl transition-colors"
           >
             Templates
           </Link>
           <Link
             href="/dashboard/chores/new"
-            className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-xl transition-colors shadow-sm"
+            className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-text-on-primary bg-primary hover:bg-primary-hover rounded-xl transition-colors shadow-sm"
           >
             <Plus className="w-4 h-4" />
             New Chore

--- a/src/app/(dashboard)/dashboard/chores/templates/page.tsx
+++ b/src/app/(dashboard)/dashboard/chores/templates/page.tsx
@@ -4,7 +4,7 @@ import { getCurrentMembership } from "@/lib/household/queries";
 import { createClient } from "@/lib/supabase/server";
 import { getChoreTemplates } from "@/lib/chores/queries";
 import { TemplateList } from "@/components/chores/template-list";
-import { Plus } from "lucide-react";
+import { Plus } from "@phosphor-icons/react/dist/ssr";
 
 export default async function ChoreTemplatesPage() {
   const membership = await getCurrentMembership();
@@ -28,23 +28,23 @@ export default async function ChoreTemplatesPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900">
+          <h1 className="text-2xl font-bold text-text-primary font-heading">
             Chore Templates
           </h1>
-          <p className="text-sm text-slate-500 mt-1">
+          <p className="text-sm text-text-secondary mt-1">
             Manage recurring chore definitions
           </p>
         </div>
         <div className="flex items-center gap-2">
           <Link
             href="/dashboard/chores"
-            className="px-4 py-2.5 text-sm font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100 rounded-xl transition-colors"
+            className="px-4 py-2.5 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-surface-secondary rounded-xl transition-colors"
           >
             Board
           </Link>
           <Link
             href="/dashboard/chores/new"
-            className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-xl transition-colors shadow-sm"
+            className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-text-on-primary bg-primary hover:bg-primary-hover rounded-xl transition-colors shadow-sm"
           >
             <Plus className="w-4 h-4" />
             New Template

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,91 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* Core palette */
+  --color-terracotta: #D97D55;
+  --color-cream: #F4E9D7;
+  --color-sage: #B8C4A9;
+  --color-teal: #6FA4AF;
+  --color-gold: #E9B63B;
+
+  /* Semantic tokens */
+  --color-primary: #6FA4AF;
+  --color-primary-hover: #5B8F9A;
+  --color-primary-light: #6FA4AF1A;
+  --color-primary-medium: #6FA4AF33;
+
+  --color-accent: #E9B63B;
+  --color-accent-light: #E9B63B1A;
+
+  --color-highlight: #D97D55;
+  --color-highlight-light: #D97D551A;
+
+  --color-surface: #FFFFFF;
+  --color-surface-secondary: #B8C4A926;
+
+  --color-background: #F4E9D7;
+  --color-foreground: #1E293B;
+
+  /* Text hierarchy */
+  --color-text-primary: #1E293B;
+  --color-text-secondary: #64748B;
+  --color-text-muted: #94A3B8;
+  --color-text-on-primary: #FFFFFF;
+
+  /* Borders */
+  --color-border: #D1D5DB;
+  --color-border-light: #E5E7EB;
+
+  /* Status (standard for accessibility) */
+  --color-error: #DC2626;
+  --color-error-light: #FEF2F2;
+  --color-error-text: #B91C1C;
+  --color-success: #16A34A;
+  --color-success-light: #F0FDF4;
+  --color-success-text: #15803D;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --color-primary: var(--color-primary);
+  --color-primary-hover: var(--color-primary-hover);
+  --color-primary-light: var(--color-primary-light);
+  --color-primary-medium: var(--color-primary-medium);
+
+  --color-accent: var(--color-accent);
+  --color-accent-light: var(--color-accent-light);
+
+  --color-highlight: var(--color-highlight);
+  --color-highlight-light: var(--color-highlight-light);
+
+  --color-surface: var(--color-surface);
+  --color-surface-secondary: var(--color-surface-secondary);
+
+  --color-background: var(--color-background);
+  --color-foreground: var(--color-foreground);
+
+  --color-text-primary: var(--color-text-primary);
+  --color-text-secondary: var(--color-text-secondary);
+  --color-text-muted: var(--color-text-muted);
+  --color-text-on-primary: var(--color-text-on-primary);
+
+  --color-border: var(--color-border);
+  --color-border-light: var(--color-border-light);
+
+  --color-error: var(--color-error);
+  --color-error-light: var(--color-error-light);
+  --color-error-text: var(--color-error-text);
+  --color-success: var(--color-success);
+  --color-success-light: var(--color-success-light);
+  --color-success-text: var(--color-success-text);
+
+  --font-sans: var(--font-inter);
+  --font-heading: var(--font-nunito);
+  --font-logo: var(--font-satisfy);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,23 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Nunito, Satisfy, Geist_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
+});
+
+const nunito = Nunito({
+  variable: "--font-nunito",
+  subsets: ["latin"],
+  weight: ["600", "700", "800"],
+});
+
+const satisfy = Satisfy({
+  variable: "--font-satisfy",
+  subsets: ["latin"],
+  weight: "400",
 });
 
 const geistMono = Geist_Mono({
@@ -26,7 +38,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${nunito.variable} ${satisfy.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>{children}</Providers>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,36 +1,129 @@
 import Link from "next/link";
-import { ArrowRight, Home } from "lucide-react";
+import {
+  ArrowRight,
+  House,
+  ClipboardText,
+  Scales,
+  Megaphone,
+} from "@phosphor-icons/react/dist/ssr";
+
+const features = [
+  {
+    icon: ClipboardText,
+    title: "Fair chore tracking",
+    description:
+      "Create, assign, and rotate chores. A points system keeps things balanced so nobody gets stuck with the dishes forever.",
+    iconBg: "bg-primary-light",
+    iconColor: "text-primary",
+  },
+  {
+    icon: Scales,
+    title: "Democratic decisions",
+    description:
+      "Put it to a vote. From picking a new couch to setting quiet hours, everyone gets a say in how the house runs.",
+    iconBg: "bg-highlight-light",
+    iconColor: "text-highlight",
+  },
+  {
+    icon: Megaphone,
+    title: "Stay in the loop",
+    description:
+      "Post announcements, share updates, and keep the whole house on the same page without endless group chats.",
+    iconBg: "bg-accent-light",
+    iconColor: "text-accent",
+  },
+];
 
 export default function LandingPage() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 p-6">
-      <div className="w-full max-w-2xl text-center space-y-8">
-        <div className="flex justify-center">
-          <div className="bg-indigo-600 p-4 rounded-3xl shadow-lg ring-8 ring-indigo-50">
-            <Home className="w-12 h-12 text-white" />
+    <div className="min-h-screen bg-background">
+      {/* Hero */}
+      <section className="min-h-[70vh] flex flex-col items-center justify-center px-6 py-16">
+        <div className="max-w-3xl mx-auto text-center space-y-6">
+          <span className="font-logo text-5xl text-primary">NestSync</span>
+
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold tracking-tight text-text-primary font-heading">
+            Your household, finally in sync.
+          </h1>
+
+          <p className="text-lg sm:text-xl text-text-secondary max-w-xl mx-auto leading-relaxed">
+            The lightweight app that helps roommates split chores, make
+            decisions together, and keep everyone in the loop.
+          </p>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 pt-4">
+            <Link
+              href="/signup"
+              className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-8 py-4 bg-primary text-text-on-primary rounded-xl font-semibold hover:bg-primary-hover transition-all shadow-sm active:scale-95"
+            >
+              <House weight="bold" className="w-5 h-5" />
+              Create your household
+            </Link>
+            <Link
+              href="/login"
+              className="inline-flex items-center justify-center gap-2 px-6 py-4 text-primary font-semibold hover:text-primary-hover transition-colors"
+            >
+              Sign in
+              <ArrowRight className="w-4 h-4" />
+            </Link>
           </div>
         </div>
+      </section>
 
-        <div className="space-y-4 pt-4">
-          <h1 className="text-5xl font-extrabold tracking-tight text-slate-900 sm:text-6xl">
-            Households without the headache.
-          </h1>
-          <p className="text-xl text-slate-600 max-w-xl mx-auto leading-relaxed">
-            NestSync combines chore tracking, expense splitting, and democratic
-            decisions into one lightweight app. No bosses. Just roommates.
+      {/* Features */}
+      <section className="bg-surface py-16 sm:py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <p className="text-sm font-semibold text-primary uppercase tracking-wider text-center mb-2">
+            How it works
           </p>
-        </div>
+          <h2 className="text-2xl sm:text-3xl font-bold text-text-primary font-heading text-center mb-10 sm:mb-12">
+            Everything your household needs
+          </h2>
 
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 pt-8">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-8">
+            {features.map((feature) => (
+              <div key={feature.title} className="text-center space-y-3">
+                <div
+                  className={`w-14 h-14 mx-auto rounded-2xl flex items-center justify-center ${feature.iconBg}`}
+                >
+                  <feature.icon
+                    weight="duotone"
+                    className={`w-7 h-7 ${feature.iconColor}`}
+                  />
+                </div>
+                <h3 className="text-lg font-bold text-text-primary font-heading">
+                  {feature.title}
+                </h3>
+                <p className="text-text-secondary leading-relaxed">
+                  {feature.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Bottom CTA */}
+      <section className="py-16 sm:py-20">
+        <div className="max-w-2xl mx-auto px-6 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-text-primary font-heading">
+            Ready to get your house in order?
+          </h2>
+          <p className="text-text-secondary mt-3 mb-8">
+            Free for up to 10 roommates. Set up in under a minute.
+          </p>
           <Link
-            href="/login"
-            className="w-full sm:w-auto flex items-center justify-center gap-2 px-8 py-4 bg-indigo-600 text-white rounded-xl font-semibold hover:bg-indigo-700 transition-all shadow-sm active:scale-95"
+            href="/signup"
+            className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-primary text-text-on-primary rounded-xl font-semibold hover:bg-primary-hover transition-all shadow-sm active:scale-95"
           >
-            Get Started
+            Get started
             <ArrowRight className="w-5 h-5" />
           </Link>
+          <p className="mt-12 text-xs text-text-muted">
+            &copy; 2026 NestSync
+          </p>
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/components/auth/auth-divider.tsx
+++ b/src/components/auth/auth-divider.tsx
@@ -2,10 +2,10 @@ export function AuthDivider() {
   return (
     <div className="relative my-6">
       <div className="absolute inset-0 flex items-center">
-        <div className="w-full border-t border-slate-200" />
+        <div className="w-full border-t border-border-light" />
       </div>
       <div className="relative flex justify-center text-sm">
-        <span className="bg-white px-4 text-slate-500">or</span>
+        <span className="bg-surface px-4 text-text-secondary">or</span>
       </div>
     </div>
   );

--- a/src/components/auth/oauth-button.tsx
+++ b/src/components/auth/oauth-button.tsx
@@ -23,7 +23,7 @@ export function GoogleOAuthButton({ inviteCode }: { inviteCode?: string }) {
     <button
       type="button"
       onClick={handleGoogleSignIn}
-      className="w-full flex items-center justify-center gap-3 px-4 py-3 border border-slate-300 rounded-xl font-medium text-slate-700 hover:bg-slate-50 transition-colors"
+      className="w-full flex items-center justify-center gap-3 px-4 py-3 border border-border rounded-xl font-medium text-text-primary hover:bg-background transition-colors"
     >
       <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
         <path

--- a/src/components/chores/chore-board.test.tsx
+++ b/src/components/chores/chore-board.test.tsx
@@ -164,6 +164,6 @@ describe("ChoreBoard", () => {
       />
     );
     const myChoresBtn = screen.getByText("My Chores");
-    expect(myChoresBtn.className).toContain("bg-white");
+    expect(myChoresBtn.className).toContain("bg-surface");
   });
 });

--- a/src/components/chores/chore-board.tsx
+++ b/src/components/chores/chore-board.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSupabase } from "@/hooks/use-supabase";
 import { ChoreCard } from "./chore-card";
-import { ClipboardList } from "lucide-react";
+import { ClipboardText } from "@phosphor-icons/react";
 import type { ChoreInstanceRow } from "@/lib/chores/queries";
 
 type Filter = "mine" | "all" | "unassigned";
@@ -65,15 +65,15 @@ export function ChoreBoard({
   return (
     <div className="space-y-4">
       {/* Filter tabs */}
-      <div className="flex gap-1 bg-slate-100 p-1 rounded-lg w-fit">
+      <div className="flex gap-1 bg-surface-secondary p-1 rounded-lg w-fit">
         {filterTabs.map((tab) => (
           <button
             key={tab.key}
             onClick={() => setFilter(tab.key)}
             className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
               filter === tab.key
-                ? "bg-white text-slate-900 shadow-sm"
-                : "text-slate-500 hover:text-slate-700"
+                ? "bg-surface text-text-primary shadow-sm"
+                : "text-text-secondary hover:text-text-primary"
             }`}
           >
             {tab.label}
@@ -84,8 +84,8 @@ export function ChoreBoard({
       {/* Chore list */}
       {!instances || instances.length === 0 ? (
         <div className="text-center py-12">
-          <ClipboardList className="w-12 h-12 text-slate-300 mx-auto mb-3" />
-          <p className="text-sm text-slate-500">
+          <ClipboardText className="w-12 h-12 text-text-muted mx-auto mb-3" />
+          <p className="text-sm text-text-secondary">
             {filter === "mine"
               ? "No chores assigned to you"
               : filter === "unassigned"

--- a/src/components/chores/chore-card.tsx
+++ b/src/components/chores/chore-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Calendar, Star, User } from "lucide-react";
+import { CalendarBlank, Star, User } from "@phosphor-icons/react";
 import { CompleteChoreButton } from "./complete-chore-button";
 
 interface ChoreCardProps {
@@ -31,28 +31,28 @@ export function ChoreCard({ instance, householdId }: ChoreCardProps) {
   );
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 p-4 flex items-center justify-between gap-4 hover:shadow-sm transition-shadow">
+    <div className="bg-surface rounded-xl border border-border-light p-4 flex items-center justify-between gap-4 hover:shadow-sm transition-shadow">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
-          <h3 className="text-sm font-medium text-slate-900 truncate">
+          <h3 className="text-sm font-medium text-text-primary truncate">
             {instance.title}
           </h3>
-          <span className="inline-flex items-center gap-0.5 text-xs text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded flex-shrink-0">
+          <span className="inline-flex items-center gap-0.5 text-xs text-accent bg-accent-light px-1.5 py-0.5 rounded flex-shrink-0">
             <Star className="w-3 h-3" />
             {instance.points}
           </span>
         </div>
-        <div className="flex items-center gap-3 text-xs text-slate-500">
+        <div className="flex items-center gap-3 text-xs text-text-secondary">
           <span
             className={`flex items-center gap-1 ${
               isOverdue
-                ? "text-red-600 font-medium"
+                ? "text-error font-medium"
                 : isToday
-                  ? "text-indigo-600 font-medium"
+                  ? "text-primary font-medium"
                   : ""
             }`}
           >
-            <Calendar className="w-3.5 h-3.5" />
+            <CalendarBlank className="w-3.5 h-3.5" />
             {isOverdue ? "Overdue · " : isToday ? "Today · " : ""}
             {formattedDate}
           </span>

--- a/src/components/chores/complete-chore-button.tsx
+++ b/src/components/chores/complete-chore-button.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { completeChore } from "@/lib/chores/actions";
-import { CheckCircle2, Loader2 } from "lucide-react";
+import { CheckCircle, SpinnerGap } from "@phosphor-icons/react";
 
 interface CompleteChoreButtonProps {
   instanceId: string;
@@ -37,13 +37,13 @@ export function CompleteChoreButton({
     <button
       onClick={() => mutation.mutate()}
       disabled={mutation.isPending}
-      className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-indigo-600 hover:text-white hover:bg-indigo-600 border border-indigo-200 hover:border-indigo-600 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+      className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-primary hover:text-text-on-primary hover:bg-primary border border-primary/30 hover:border-primary rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed"
       aria-label="Mark this chore as complete"
     >
       {mutation.isPending ? (
-        <Loader2 className="w-4 h-4 animate-spin" />
+        <SpinnerGap className="w-4 h-4 animate-spin" />
       ) : (
-        <CheckCircle2 className="w-4 h-4" />
+        <CheckCircle className="w-4 h-4" />
       )}
       Done
     </button>

--- a/src/components/chores/create-chore-form.tsx
+++ b/src/components/chores/create-chore-form.tsx
@@ -23,7 +23,7 @@ export function CreateChoreForm({ members }: CreateChoreFormProps) {
     <form action={formAction} className="space-y-4" noValidate>
       {state.error && (
         <div
-          className="p-3 rounded-lg bg-red-50 text-red-700 text-sm"
+          className="p-3 rounded-lg bg-error-light text-error-text text-sm"
           role="alert"
         >
           {state.error}
@@ -42,17 +42,17 @@ export function CreateChoreForm({ members }: CreateChoreFormProps) {
       <div className="space-y-1.5">
         <label
           htmlFor="chore-description"
-          className="block text-sm font-medium text-slate-700"
+          className="block text-sm font-medium text-text-primary"
         >
           Description{" "}
-          <span className="text-slate-400 font-normal">(optional)</span>
+          <span className="text-text-muted font-normal">(optional)</span>
         </label>
         <textarea
           id="chore-description"
           name="description"
           placeholder="What does this chore involve?"
           rows={3}
-          className="w-full px-3 py-2.5 rounded-lg border border-slate-300 text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow resize-none"
+          className="w-full px-3 py-2.5 rounded-lg border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-shadow resize-none"
         />
       </div>
 
@@ -69,7 +69,7 @@ export function CreateChoreForm({ members }: CreateChoreFormProps) {
         <div className="space-y-1.5">
           <label
             htmlFor="chore-recurrence"
-            className="block text-sm font-medium text-slate-700"
+            className="block text-sm font-medium text-text-primary"
           >
             Recurrence
           </label>
@@ -77,7 +77,7 @@ export function CreateChoreForm({ members }: CreateChoreFormProps) {
             id="chore-recurrence"
             name="recurrence"
             defaultValue="weekly"
-            className="w-full px-3 py-2.5 rounded-lg border border-slate-300 text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow bg-white"
+            className="w-full px-3 py-2.5 rounded-lg border border-border text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-shadow bg-surface"
           >
             <option value="one_time">One-time</option>
             <option value="daily">Daily</option>
@@ -90,7 +90,7 @@ export function CreateChoreForm({ members }: CreateChoreFormProps) {
       <div className="space-y-1.5">
         <label
           htmlFor="chore-assignee"
-          className="block text-sm font-medium text-slate-700"
+          className="block text-sm font-medium text-text-primary"
         >
           Assigned to
         </label>
@@ -98,7 +98,7 @@ export function CreateChoreForm({ members }: CreateChoreFormProps) {
           id="chore-assignee"
           name="assignedTo"
           defaultValue={members[0]?.id ?? ""}
-          className="w-full px-3 py-2.5 rounded-lg border border-slate-300 text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow bg-white"
+          className="w-full px-3 py-2.5 rounded-lg border border-border text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-shadow bg-surface"
         >
           {members.map((member) => (
             <option key={member.id} value={member.id}>
@@ -110,10 +110,10 @@ export function CreateChoreForm({ members }: CreateChoreFormProps) {
 
       <SubmitButton>Create chore</SubmitButton>
 
-      <p className="text-center text-sm text-slate-500">
+      <p className="text-center text-sm text-text-secondary">
         <Link
           href="/dashboard/chores"
-          className="text-indigo-600 font-medium hover:text-indigo-700"
+          className="text-primary font-medium hover:text-primary-hover"
         >
           Back to chore board
         </Link>

--- a/src/components/chores/template-card.tsx
+++ b/src/components/chores/template-card.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteChoreTemplate } from "@/lib/chores/actions";
-import { Repeat, Trash2, Star, Loader2, User } from "lucide-react";
+import { ArrowsClockwise, Trash, Star, SpinnerGap, User } from "@phosphor-icons/react";
 
 interface TemplateCardProps {
   template: {
@@ -54,14 +54,14 @@ export function TemplateCard({
   });
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 p-4 space-y-3">
+    <div className="bg-surface rounded-xl border border-border-light p-4 space-y-3">
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-semibold text-slate-900 truncate">
+          <h3 className="text-sm font-semibold text-text-primary truncate">
             {template.title}
           </h3>
           {template.description && (
-            <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">
+            <p className="text-xs text-text-secondary mt-0.5 line-clamp-2">
               {template.description}
             </p>
           )}
@@ -70,30 +70,30 @@ export function TemplateCard({
           <button
             onClick={() => deleteMutation.mutate()}
             disabled={deleteMutation.isPending}
-            className="p-1.5 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0"
+            className="p-1.5 text-text-muted hover:text-error hover:bg-error-light rounded-lg transition-colors flex-shrink-0"
             title="Delete template"
           >
             {deleteMutation.isPending ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
+              <SpinnerGap className="w-4 h-4 animate-spin" />
             ) : (
-              <Trash2 className="w-4 h-4" />
+              <Trash className="w-4 h-4" />
             )}
           </button>
         )}
       </div>
 
       <div className="flex flex-wrap items-center gap-2">
-        <span className="inline-flex items-center gap-1 text-xs bg-indigo-50 text-indigo-600 px-2 py-1 rounded-md">
-          <Repeat className="w-3 h-3" />
+        <span className="inline-flex items-center gap-1 text-xs bg-primary-light text-primary px-2 py-1 rounded-md">
+          <ArrowsClockwise className="w-3 h-3" />
           {recurrenceLabels[template.recurrence] ?? template.recurrence}
         </span>
-        <span className="inline-flex items-center gap-1 text-xs bg-amber-50 text-amber-600 px-2 py-1 rounded-md">
+        <span className="inline-flex items-center gap-1 text-xs bg-accent-light text-accent px-2 py-1 rounded-md">
           <Star className="w-3 h-3" />
           {template.points} {template.points === 1 ? "point" : "points"}
         </span>
       </div>
 
-      <div className="flex items-center gap-3 text-xs text-slate-500">
+      <div className="flex items-center gap-3 text-xs text-text-secondary">
         <span className="flex items-center gap-1">
           <User className="w-3.5 h-3.5" />
           {template.assigned_member?.users?.display_name ?? "Unassigned"}

--- a/src/components/chores/template-list.tsx
+++ b/src/components/chores/template-list.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useSupabase } from "@/hooks/use-supabase";
 import { TemplateCard } from "./template-card";
-import { ClipboardList } from "lucide-react";
+import { ClipboardText } from "@phosphor-icons/react";
 import type { ChoreTemplateRow } from "@/lib/chores/queries";
 
 interface TemplateListProps {
@@ -53,8 +53,8 @@ export function TemplateList({
   if (!templates || templates.length === 0) {
     return (
       <div className="text-center py-12">
-        <ClipboardList className="w-12 h-12 text-slate-300 mx-auto mb-3" />
-        <p className="text-sm text-slate-500">No chore templates yet</p>
+        <ClipboardText className="w-12 h-12 text-text-muted mx-auto mb-3" />
+        <p className="text-sm text-text-secondary">No chore templates yet</p>
       </div>
     );
   }

--- a/src/components/chores/weekly-stats.tsx
+++ b/src/components/chores/weekly-stats.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useSupabase } from "@/hooks/use-supabase";
-import { Trophy, Star } from "lucide-react";
+import { Trophy, Star } from "@phosphor-icons/react";
 
 interface WeeklyStatsProps {
   householdId: string;
@@ -82,20 +82,20 @@ export function WeeklyStats({ householdId, initialStats }: WeeklyStatsProps) {
 
   if (!stats || stats.length === 0) {
     return (
-      <div className="bg-white rounded-xl border border-slate-200 p-5">
-        <h3 className="text-sm font-semibold text-slate-900 flex items-center gap-2 mb-3">
-          <Trophy className="w-4 h-4 text-amber-500" />
+      <div className="bg-surface rounded-xl border border-border-light p-5">
+        <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2 mb-3">
+          <Trophy className="w-4 h-4 text-accent" />
           This Week&apos;s Points
         </h3>
-        <p className="text-sm text-slate-400">No chores completed this week</p>
+        <p className="text-sm text-text-muted">No chores completed this week</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-xl border border-slate-200 p-5">
-      <h3 className="text-sm font-semibold text-slate-900 flex items-center gap-2 mb-3">
-        <Trophy className="w-4 h-4 text-amber-500" />
+    <div className="bg-surface rounded-xl border border-border-light p-5">
+      <h3 className="text-sm font-semibold text-text-primary flex items-center gap-2 mb-3">
+        <Trophy className="w-4 h-4 text-accent" />
         This Week&apos;s Points
       </h3>
       <div className="space-y-2">
@@ -108,22 +108,22 @@ export function WeeklyStats({ householdId, initialStats }: WeeklyStatsProps) {
               <span
                 className={`text-xs font-bold w-5 text-center ${
                   index === 0
-                    ? "text-amber-500"
+                    ? "text-accent"
                     : index === 1
-                      ? "text-slate-400"
-                      : "text-amber-700"
+                      ? "text-text-muted"
+                      : "text-highlight"
                 }`}
               >
                 {index + 1}
               </span>
-              <span className="text-sm text-slate-700">
+              <span className="text-sm text-text-primary">
                 {stat.displayName}
               </span>
             </div>
             <div className="flex items-center gap-1 text-sm">
-              <Star className="w-3.5 h-3.5 text-amber-500" />
-              <span className="font-medium text-slate-900">{stat.points}</span>
-              <span className="text-slate-400">
+              <Star className="w-3.5 h-3.5 text-accent" />
+              <span className="font-medium text-text-primary">{stat.points}</span>
+              <span className="text-text-muted">
                 ({stat.count} {stat.count === 1 ? "chore" : "chores"})
               </span>
             </div>

--- a/src/components/dashboard/dashboard-home.tsx
+++ b/src/components/dashboard/dashboard-home.tsx
@@ -2,11 +2,11 @@
 
 import Link from "next/link";
 import {
-  ClipboardList,
-  Calendar,
+  ClipboardText,
+  CalendarBlank,
   Star,
   ArrowRight,
-} from "lucide-react";
+} from "@phosphor-icons/react";
 import { WeeklyStats } from "@/components/chores/weekly-stats";
 
 interface ChoreInstance {
@@ -53,52 +53,52 @@ export function DashboardHome({
     <div className="space-y-6">
       {/* Welcome header */}
       <div>
-        <h1 className="text-2xl font-bold text-slate-900">
+        <h1 className="text-2xl font-bold text-text-primary font-heading">
           Welcome back, {userName}
         </h1>
-        <p className="text-slate-500 mt-1">{today}</p>
+        <p className="text-text-secondary mt-1">{today}</p>
       </div>
 
       {/* Quick stats */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div className="bg-white rounded-xl border border-slate-200 p-5">
+        <div className="bg-surface rounded-xl border border-border-light p-5">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-indigo-50 rounded-lg flex items-center justify-center">
-              <ClipboardList className="w-5 h-5 text-indigo-600" />
+            <div className="w-10 h-10 bg-primary-light rounded-lg flex items-center justify-center">
+              <ClipboardText className="w-5 h-5 text-primary" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-slate-900">
+              <p className="text-2xl font-bold text-text-primary">
                 {myPendingCount}
               </p>
-              <p className="text-sm text-slate-500">My pending chores</p>
+              <p className="text-sm text-text-secondary">My pending chores</p>
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-xl border border-slate-200 p-5">
+        <div className="bg-surface rounded-xl border border-border-light p-5">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-emerald-50 rounded-lg flex items-center justify-center">
-              <Calendar className="w-5 h-5 text-emerald-600" />
+            <div className="w-10 h-10 bg-highlight-light rounded-lg flex items-center justify-center">
+              <CalendarBlank className="w-5 h-5 text-highlight" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-slate-900">
+              <p className="text-2xl font-bold text-text-primary">
                 {todayChores.length}
               </p>
-              <p className="text-sm text-slate-500">Due today</p>
+              <p className="text-sm text-text-secondary">Due today</p>
             </div>
           </div>
         </div>
 
-        <div className="bg-white rounded-xl border border-slate-200 p-5">
+        <div className="bg-surface rounded-xl border border-border-light p-5">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-amber-50 rounded-lg flex items-center justify-center">
-              <Star className="w-5 h-5 text-amber-600" />
+            <div className="w-10 h-10 bg-accent-light rounded-lg flex items-center justify-center">
+              <Star className="w-5 h-5 text-accent" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-slate-900">
+              <p className="text-2xl font-bold text-text-primary">
                 {totalPendingCount}
               </p>
-              <p className="text-sm text-slate-500">Total household chores</p>
+              <p className="text-sm text-text-secondary">Total household chores</p>
             </div>
           </div>
         </div>
@@ -106,20 +106,20 @@ export function DashboardHome({
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Today's chores */}
-        <div className="bg-white rounded-xl border border-slate-200 p-5">
+        <div className="bg-surface rounded-xl border border-border-light p-5">
           <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-semibold text-slate-900">
+            <h3 className="text-sm font-semibold text-text-primary">
               Today&apos;s Chores
             </h3>
             <Link
               href="/dashboard/chores"
-              className="text-sm text-indigo-600 hover:text-indigo-700 flex items-center gap-1"
+              className="text-sm text-primary hover:text-primary-hover flex items-center gap-1"
             >
               View all <ArrowRight className="w-3.5 h-3.5" />
             </Link>
           </div>
           {todayChores.length === 0 ? (
-            <p className="text-sm text-slate-400">
+            <p className="text-sm text-text-muted">
               No chores due today. Enjoy your day!
             </p>
           ) : (
@@ -127,18 +127,18 @@ export function DashboardHome({
               {todayChores.slice(0, 5).map((chore) => (
                 <div
                   key={chore.id}
-                  className="flex items-center justify-between py-2 border-b border-slate-50 last:border-0"
+                  className="flex items-center justify-between py-2 border-b border-border-light/50 last:border-0"
                 >
                   <div className="flex items-center gap-2">
-                    <span className="text-sm text-slate-700">
+                    <span className="text-sm text-text-primary">
                       {chore.title}
                     </span>
-                    <span className="inline-flex items-center gap-0.5 text-xs text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded">
+                    <span className="inline-flex items-center gap-0.5 text-xs text-accent bg-accent-light px-1.5 py-0.5 rounded">
                       <Star className="w-3 h-3" />
                       {chore.points}
                     </span>
                   </div>
-                  <span className="text-xs text-slate-400">
+                  <span className="text-xs text-text-muted">
                     {chore.assigned_member?.users?.display_name ?? "Unassigned"}
                   </span>
                 </div>

--- a/src/components/dashboard/dashboard-shell.tsx
+++ b/src/components/dashboard/dashboard-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { X } from "lucide-react";
+import { X } from "@phosphor-icons/react";
 import { SidebarNav } from "./sidebar-nav";
 import { TopBar } from "./top-bar";
 import type { CurrentMembership } from "@/lib/household/queries";
@@ -22,7 +22,7 @@ export function DashboardShell({
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-background">
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div
@@ -33,22 +33,22 @@ export function DashboardShell({
 
       {/* Sidebar */}
       <aside
-        className={`fixed inset-y-0 left-0 z-50 w-64 bg-white border-r border-slate-200 transform transition-transform lg:translate-x-0 lg:static lg:z-auto ${
+        className={`fixed inset-y-0 left-0 z-50 w-64 bg-surface border-r border-border-light transform transition-transform lg:translate-x-0 lg:static lg:z-auto ${
           sidebarOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
         <div className="flex flex-col h-full">
           {/* Sidebar header */}
-          <div className="h-16 flex items-center justify-between px-4 border-b border-slate-200">
+          <div className="h-16 flex items-center justify-between px-4 border-b border-border-light">
             <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-lg bg-indigo-600 flex items-center justify-center">
-                <span className="text-white text-sm font-bold">N</span>
+              <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+                <span className="text-text-on-primary text-sm font-logo">N</span>
               </div>
-              <span className="font-semibold text-slate-900">NestSync</span>
+              <span className="font-logo text-xl text-primary">NestSync</span>
             </div>
             <button
               onClick={() => setSidebarOpen(false)}
-              className="lg:hidden p-1 rounded text-slate-400 hover:text-slate-600"
+              className="lg:hidden p-1 rounded text-text-muted hover:text-text-secondary"
               aria-label="Close sidebar"
             >
               <X className="w-5 h-5" />
@@ -56,11 +56,11 @@ export function DashboardShell({
           </div>
 
           {/* Household name */}
-          <div className="px-4 py-3 border-b border-slate-100">
-            <p className="text-xs text-slate-400 uppercase tracking-wider font-medium">
+          <div className="px-4 py-3 border-b border-border-light">
+            <p className="text-xs text-text-muted uppercase tracking-wider font-medium">
               Household
             </p>
-            <p className="text-sm font-medium text-slate-700 truncate mt-0.5">
+            <p className="text-sm font-medium text-text-primary truncate mt-0.5">
               {household.name}
             </p>
           </div>
@@ -71,8 +71,8 @@ export function DashboardShell({
           </div>
 
           {/* Sidebar footer */}
-          <div className="px-4 py-3 border-t border-slate-200">
-            <p className="text-xs text-slate-400 truncate">
+          <div className="px-4 py-3 border-t border-border-light">
+            <p className="text-xs text-text-muted truncate">
               {user.display_name} ·{" "}
               {membership.role === "admin" ? "Admin" : "Member"}
             </p>

--- a/src/components/dashboard/sidebar-nav.test.tsx
+++ b/src/components/dashboard/sidebar-nav.test.tsx
@@ -66,24 +66,24 @@ describe("SidebarNav", () => {
     mockPathname.mockReturnValue("/dashboard");
     render(<SidebarNav />);
     const homeLink = screen.getByText("Home").closest("a");
-    expect(homeLink?.className).toContain("indigo");
+    expect(homeLink?.className).toContain("bg-primary-light");
   });
 
   it("highlights Chores when on /dashboard/chores", () => {
     mockPathname.mockReturnValue("/dashboard/chores");
     render(<SidebarNav />);
     const choresLink = screen.getByText("Chores").closest("a");
-    expect(choresLink?.className).toContain("indigo");
+    expect(choresLink?.className).toContain("bg-primary-light");
     // Home should NOT be highlighted
     const homeLink = screen.getByText("Home").closest("a");
-    expect(homeLink?.className).not.toContain("indigo");
+    expect(homeLink?.className).not.toContain("bg-primary-light");
   });
 
   it("highlights Chores when on sub-route /dashboard/chores/new", () => {
     mockPathname.mockReturnValue("/dashboard/chores/new");
     render(<SidebarNav />);
     const choresLink = screen.getByText("Chores").closest("a");
-    expect(choresLink?.className).toContain("indigo");
+    expect(choresLink?.className).toContain("bg-primary-light");
   });
 
   it("calls onNavigate when a link is clicked", () => {

--- a/src/components/dashboard/sidebar-nav.tsx
+++ b/src/components/dashboard/sidebar-nav.tsx
@@ -2,30 +2,31 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { Icon } from "@phosphor-icons/react";
 import {
-  Home,
-  ClipboardList,
-  DollarSign,
+  House,
+  ClipboardText,
+  CurrencyDollar,
   Megaphone,
-  Vote,
-} from "lucide-react";
+  Scales,
+} from "@phosphor-icons/react";
 
-const navItems = [
-  { href: "/dashboard", label: "Home", icon: Home, enabled: true },
+const navItems: { href: string; label: string; icon: Icon; enabled: boolean }[] = [
+  { href: "/dashboard", label: "Home", icon: House, enabled: true },
   {
     href: "/dashboard/chores",
     label: "Chores",
-    icon: ClipboardList,
+    icon: ClipboardText,
     enabled: true,
   },
   {
     href: "/dashboard/expenses",
     label: "Expenses",
-    icon: DollarSign,
+    icon: CurrencyDollar,
     enabled: false,
   },
   { href: "/dashboard/feed", label: "Feed", icon: Megaphone, enabled: false },
-  { href: "/dashboard/votes", label: "Votes", icon: Vote, enabled: false },
+  { href: "/dashboard/votes", label: "Votes", icon: Scales, enabled: false },
 ];
 
 export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
@@ -43,12 +44,12 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
           return (
             <div
               key={item.href}
-              className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-slate-400 cursor-not-allowed"
+              className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-text-muted cursor-not-allowed"
               title="Coming soon"
             >
               <item.icon className="w-5 h-5" />
               <span className="text-sm font-medium">{item.label}</span>
-              <span className="ml-auto text-xs bg-slate-100 text-slate-400 px-1.5 py-0.5 rounded">
+              <span className="ml-auto text-xs bg-surface-secondary text-text-muted px-1.5 py-0.5 rounded">
                 Soon
               </span>
             </div>
@@ -62,8 +63,8 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
             onClick={onNavigate}
             className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors ${
               isActive
-                ? "bg-indigo-50 text-indigo-700"
-                : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                ? "bg-primary-light text-primary-hover"
+                : "text-text-secondary hover:bg-surface-secondary hover:text-text-primary"
             }`}
           >
             <item.icon className="w-5 h-5" />

--- a/src/components/dashboard/top-bar.tsx
+++ b/src/components/dashboard/top-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Check, LogOut, Menu } from "lucide-react";
+import { Copy, Check, SignOut, List } from "@phosphor-icons/react";
 import { signOut } from "@/lib/auth/actions";
 
 interface TopBarProps {
@@ -30,16 +30,16 @@ export function TopBar({
   };
 
   return (
-    <header className="h-16 border-b border-slate-200 bg-white flex items-center justify-between px-4 lg:px-6">
+    <header className="h-16 border-b border-border-light bg-surface flex items-center justify-between px-4 lg:px-6">
       <div className="flex items-center gap-3">
         <button
           onClick={onMenuToggle}
-          className="lg:hidden p-2 rounded-lg text-slate-500 hover:bg-slate-100"
+          className="lg:hidden p-2 rounded-lg text-text-secondary hover:bg-surface-secondary"
           aria-label="Toggle sidebar"
         >
-          <Menu className="w-5 h-5" />
+          <List className="w-5 h-5" />
         </button>
-        <h2 className="text-sm font-semibold text-slate-900 hidden sm:block">
+        <h2 className="text-sm font-semibold text-text-primary hidden sm:block">
           {householdName}
         </h2>
       </div>
@@ -47,12 +47,12 @@ export function TopBar({
       <div className="flex items-center gap-2">
         <button
           onClick={copyInviteCode}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-600 hover:text-slate-900 hover:bg-slate-100 rounded-lg transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-secondary rounded-lg transition-colors"
           title={`Invite code: ${inviteCode}`}
           aria-label={copied ? "Invite code copied" : "Copy invite code"}
         >
           {copied ? (
-            <Check className="w-4 h-4 text-green-600" />
+            <Check className="w-4 h-4 text-success" />
           ) : (
             <Copy className="w-4 h-4" />
           )}
@@ -61,18 +61,18 @@ export function TopBar({
           </span>
         </button>
 
-        <span className="text-sm text-slate-500 hidden md:inline">
+        <span className="text-sm text-text-secondary hidden md:inline">
           {userName}
         </span>
 
         <form action={signOut}>
           <button
             type="submit"
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary hover:text-error hover:bg-error-light rounded-lg transition-colors"
             title="Sign out"
             aria-label="Sign out"
           >
-            <LogOut className="w-4 h-4" />
+            <SignOut className="w-4 h-4" />
             <span className="hidden sm:inline">Sign out</span>
           </button>
         </form>

--- a/src/components/ui/form-field.tsx
+++ b/src/components/ui/form-field.tsx
@@ -25,7 +25,7 @@ export function FormField({
 }: FormFieldProps) {
   return (
     <div className="space-y-1.5">
-      <label htmlFor={id} className="block text-sm font-medium text-slate-700">
+      <label htmlFor={id} className="block text-sm font-medium text-text-primary">
         {label}
       </label>
       <input
@@ -38,10 +38,10 @@ export function FormField({
         autoComplete={autoComplete}
         aria-describedby={error ? `${id}-error` : undefined}
         aria-invalid={error ? true : undefined}
-        className="w-full px-3 py-2.5 rounded-lg border border-slate-300 text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
+        className="w-full px-3 py-2.5 rounded-lg border border-border text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-shadow"
       />
       {error && (
-        <p id={`${id}-error`} className="text-sm text-red-600" role="alert">
+        <p id={`${id}-error`} className="text-sm text-error" role="alert">
           {error}
         </p>
       )}

--- a/src/components/ui/submit-button.tsx
+++ b/src/components/ui/submit-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useFormStatus } from "react-dom";
-import { Loader2 } from "lucide-react";
+import { SpinnerGap } from "@phosphor-icons/react";
 
 interface SubmitButtonProps {
   children: React.ReactNode;
@@ -16,9 +16,9 @@ export function SubmitButton({ children, className }: SubmitButtonProps) {
       type="submit"
       disabled={pending}
       aria-busy={pending}
-      className={`w-full flex items-center justify-center gap-2 px-4 py-3 bg-indigo-600 text-white rounded-xl font-semibold hover:bg-indigo-700 transition-all shadow-sm active:scale-[0.98] disabled:opacity-60 disabled:cursor-not-allowed ${className ?? ""}`}
+      className={`w-full flex items-center justify-center gap-2 px-4 py-3 bg-primary text-text-on-primary rounded-xl font-semibold hover:bg-primary-hover transition-all shadow-sm active:scale-[0.98] disabled:opacity-60 disabled:cursor-not-allowed ${className ?? ""}`}
     >
-      {pending && <Loader2 className="w-4 h-4 animate-spin" />}
+      {pending && <SpinnerGap className="w-4 h-4 animate-spin" />}
       {children}
     </button>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "nestsync-logo-preview"
   ]
 }


### PR DESCRIPTION
## Summary
- Implement warm pastel color palette (teal, cream, sage, terracotta, gold) with semantic CSS tokens across 40 files
- Migrate icon library from lucide-react to Phosphor Icons
- Add Nunito (headings), Inter (body), and Satisfy (logo) typography via next/font/google
- Redesign landing page with 3-section layout (hero, features, bottom CTA) and updated copy removing deprecated expenses feature
- Add comprehensive design system document (`docs/DESIGN.md`)

## Test plan
- [x] `npm run build` passes
- [x] All 261 unit tests pass (25 test files)
- [x] Visual verification on desktop and mobile viewports
- [x] No console errors
- [ ] Manual smoke test of auth pages, dashboard, and chore board

🤖 Generated with [Claude Code](https://claude.com/claude-code)