### PR TITLE
feat: vote/governance feature

### DIFF
--- a/src/app/(dashboard)/dashboard/votes/page.tsx
+++ b/src/app/(dashboard)/dashboard/votes/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "next/navigation";
+import { getCurrentMembership } from "@/lib/household/queries";
+import { getProposals } from "@/lib/proposals/queries";
+import { expireProposals } from "@/lib/proposals/actions";
+import { getHouseholdMembers } from "@/lib/household/members";
+import { createClient } from "@/lib/supabase/server";
+import { ProposalFeed } from "@/components/proposals/proposal-feed";
+
+export default async function VotesPage() {
+  const membership = await getCurrentMembership();
+  if (!membership) redirect("/login");
+
+  // Resolve overdue proposals before rendering
+  await expireProposals();
+
+  const supabase = await createClient();
+
+  const [proposals, members, memberData] = await Promise.all([
+    getProposals(membership.householdId),
+    getHouseholdMembers(membership.householdId),
+    supabase
+      .from("household_members")
+      .select("joined_at")
+      .eq("id", membership.memberId)
+      .single(),
+  ]);
+
+  const joinedAt = memberData.data?.joined_at ?? new Date().toISOString();
+
+  return (
+    <div className="max-w-5xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary font-heading">
+          Votes
+        </h1>
+        <p className="text-sm text-text-secondary mt-1">
+          Household proposals and governance
+        </p>
+      </div>
+
+      <ProposalFeed
+        initialProposals={proposals}
+        householdId={membership.householdId}
+        currentMemberId={membership.memberId}
+        currentMemberJoinedAt={joinedAt}
+        currentMemberRole={membership.role}
+        members={members}
+      />
+    </div>
+  );
+}

--- a/src/components/dashboard/sidebar-nav.test.tsx
+++ b/src/components/dashboard/sidebar-nav.test.tsx
@@ -36,7 +36,7 @@ describe("SidebarNav", () => {
     expect(screen.getByText("Votes")).toBeInTheDocument();
   });
 
-  it("renders enabled items as links", () => {
+  it("renders all items as links", () => {
     mockPathname.mockReturnValue("/dashboard");
     render(<SidebarNav />);
     const homeLink = screen.getByText("Home").closest("a");
@@ -47,23 +47,14 @@ describe("SidebarNav", () => {
     expect(householdLink).toHaveAttribute("href", "/dashboard/household");
     const calendarLink = screen.getByText("Calendar").closest("a");
     expect(calendarLink).toHaveAttribute("href", "/dashboard/calendar");
+    const votesLink = screen.getByText("Votes").closest("a");
+    expect(votesLink).toHaveAttribute("href", "/dashboard/votes");
   });
 
-  it("renders disabled items as non-clickable divs", () => {
+  it("does not show any 'Soon' badges when all items are enabled", () => {
     mockPathname.mockReturnValue("/dashboard");
     render(<SidebarNav />);
-    const votesEl = screen.getByText("Votes").closest("div");
-    expect(votesEl).not.toBeNull();
-    expect(votesEl?.tagName).toBe("DIV");
-    expect(screen.getByText("Votes").closest("a")).toBeNull();
-  });
-
-  it("shows 'Soon' badge for disabled items", () => {
-    mockPathname.mockReturnValue("/dashboard");
-    render(<SidebarNav />);
-    const soonBadges = screen.getAllByText("Soon");
-    // Only Votes is disabled
-    expect(soonBadges).toHaveLength(1);
+    expect(screen.queryByText("Soon")).toBeNull();
   });
 
   it("highlights Home when on /dashboard", () => {

--- a/src/components/dashboard/sidebar-nav.tsx
+++ b/src/components/dashboard/sidebar-nav.tsx
@@ -18,7 +18,7 @@ const navItems: { href: string; label: string; icon: Icon; enabled: boolean }[] 
   { href: "/dashboard/household", label: "Household", icon: UsersThree, enabled: true },
   { href: "/dashboard/calendar", label: "Calendar", icon: CalendarDots, enabled: true },
   { href: "/dashboard/feed", label: "Feed", icon: Megaphone, enabled: true },
-  { href: "/dashboard/votes", label: "Votes", icon: Scales, enabled: false },
+  { href: "/dashboard/votes", label: "Votes", icon: Scales, enabled: true },
 ];
 
 export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {

--- a/src/components/proposals/create-proposal-form.tsx
+++ b/src/components/proposals/create-proposal-form.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Crown,
+  UserMinus,
+  Scales,
+  SpinnerGap,
+  PaperPlaneTilt,
+  Plus,
+  X,
+} from "@phosphor-icons/react";
+import { createProposal } from "@/lib/proposals/actions";
+import type { HouseholdMemberWithUser } from "@/lib/household/members";
+
+interface CreateProposalFormProps {
+  householdId: string;
+  members: HouseholdMemberWithUser[];
+  currentMemberRole: "admin" | "member";
+}
+
+const PROPOSAL_TYPES = [
+  {
+    value: "elect_admin" as const,
+    label: "Admin Election",
+    icon: Crown,
+    description: "Nominate a new household admin",
+  },
+  {
+    value: "remove_member" as const,
+    label: "Remove Member",
+    icon: UserMinus,
+    description: "Vote to remove a household member",
+  },
+  {
+    value: "custom" as const,
+    label: "Custom Vote",
+    icon: Scales,
+    description: "Create a custom proposal for your household",
+  },
+];
+
+export function CreateProposalForm({
+  householdId,
+  members,
+  currentMemberRole,
+}: CreateProposalFormProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [type, setType] = useState<"elect_admin" | "remove_member" | "custom">(
+    "custom"
+  );
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [targetMemberId, setTargetMemberId] = useState("");
+  const [durationHours, setDurationHours] = useState("48");
+  const queryClient = useQueryClient();
+
+  const needsTarget = type === "elect_admin" || type === "remove_member";
+
+  // Filter members for target dropdown
+  const targetOptions =
+    type === "elect_admin"
+      ? members.filter((m) => m.role !== "admin")
+      : members;
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const formData = new FormData();
+      formData.set("type", type);
+      formData.set("title", title.trim());
+      formData.set("description", description.trim());
+      if (needsTarget && targetMemberId) {
+        formData.set("targetMemberId", targetMemberId);
+      }
+      if (durationHours) {
+        formData.set("durationHours", durationHours);
+      }
+      return createProposal(formData);
+    },
+    onSuccess: (result) => {
+      if (result.success) {
+        // Reset form
+        setTitle("");
+        setDescription("");
+        setTargetMemberId("");
+        setDurationHours("48");
+        setType("custom");
+        setIsOpen(false);
+        queryClient.invalidateQueries({
+          queryKey: ["proposals", householdId],
+        });
+      }
+    },
+  });
+
+  const error = mutation.data?.error;
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-text-on-primary bg-primary hover:bg-primary-hover rounded-xl transition-colors shadow-sm"
+      >
+        <Plus className="w-4 h-4" />
+        New Proposal
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-surface rounded-xl border border-border-light p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-text-primary">
+          Create Proposal
+        </h3>
+        <button
+          onClick={() => setIsOpen(false)}
+          className="p-1 rounded-lg text-text-muted hover:text-text-secondary hover:bg-surface-secondary transition-colors"
+          aria-label="Cancel"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 text-sm text-error-text bg-error-light px-3 py-2 rounded-lg"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Type selector */}
+      <div className="mb-4">
+        <label className="block text-xs font-medium text-text-secondary mb-2">
+          Proposal type
+        </label>
+        <div className="grid grid-cols-3 gap-2">
+          {PROPOSAL_TYPES.map((pt) => {
+            const Icon = pt.icon;
+            const selected = type === pt.value;
+            return (
+              <button
+                key={pt.value}
+                type="button"
+                onClick={() => {
+                  setType(pt.value);
+                  setTargetMemberId("");
+                }}
+                className={`flex flex-col items-center gap-1.5 p-3 rounded-xl border text-xs font-medium transition-colors ${
+                  selected
+                    ? "border-primary bg-primary-light text-primary"
+                    : "border-border-light bg-background text-text-secondary hover:bg-surface-secondary"
+                }`}
+              >
+                <Icon
+                  className="w-5 h-5"
+                  weight={selected ? "fill" : "regular"}
+                />
+                {pt.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Title */}
+      <div className="mb-3">
+        <label
+          htmlFor="proposal-title"
+          className="block text-xs font-medium text-text-secondary mb-1"
+        >
+          Title
+        </label>
+        <input
+          id="proposal-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder={
+            type === "elect_admin"
+              ? "Elect new admin"
+              : type === "remove_member"
+                ? "Remove inactive member"
+                : "Your proposal title..."
+          }
+          maxLength={200}
+          className="w-full rounded-lg border border-border-light bg-background px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+        />
+      </div>
+
+      {/* Description */}
+      <div className="mb-3">
+        <label
+          htmlFor="proposal-desc"
+          className="block text-xs font-medium text-text-secondary mb-1"
+        >
+          Description{" "}
+          <span className="text-text-muted font-normal">(optional)</span>
+        </label>
+        <textarea
+          id="proposal-desc"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Explain your proposal..."
+          rows={3}
+          maxLength={2000}
+          className="w-full resize-none rounded-lg border border-border-light bg-background px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+        />
+      </div>
+
+      {/* Target member (conditional) */}
+      {needsTarget && (
+        <div className="mb-3">
+          <label
+            htmlFor="proposal-target"
+            className="block text-xs font-medium text-text-secondary mb-1"
+          >
+            {type === "elect_admin" ? "Nominee" : "Member to remove"}
+          </label>
+          <select
+            id="proposal-target"
+            value={targetMemberId}
+            onChange={(e) => setTargetMemberId(e.target.value)}
+            className="w-full rounded-lg border border-border-light bg-background px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+          >
+            <option value="">Select a member...</option>
+            {targetOptions.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.users.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Duration */}
+      <div className="mb-4">
+        <label
+          htmlFor="proposal-duration"
+          className="block text-xs font-medium text-text-secondary mb-1"
+        >
+          Voting period (hours)
+        </label>
+        <input
+          id="proposal-duration"
+          type="number"
+          value={durationHours}
+          onChange={(e) => setDurationHours(e.target.value)}
+          min={1}
+          max={168}
+          className="w-32 rounded-lg border border-border-light bg-background px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+        />
+      </div>
+
+      {/* Submit */}
+      <button
+        onClick={() => mutation.mutate()}
+        disabled={mutation.isPending || !title.trim()}
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-on-primary bg-primary hover:bg-primary-hover rounded-lg transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {mutation.isPending ? (
+          <SpinnerGap className="w-4 h-4 animate-spin" />
+        ) : (
+          <PaperPlaneTilt className="w-4 h-4" />
+        )}
+        Create Proposal
+      </button>
+    </div>
+  );
+}

--- a/src/components/proposals/proposal-card.tsx
+++ b/src/components/proposals/proposal-card.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Crown,
+  UserMinus,
+  Scales,
+  Timer,
+  CheckCircle,
+  XCircle,
+  SpinnerGap,
+  Check,
+} from "@phosphor-icons/react";
+import { castVote } from "@/lib/proposals/actions";
+import { VoteProgressBar } from "./vote-progress-bar";
+import type { ProposalWithDetails } from "@/lib/proposals/queries";
+
+interface ProposalCardProps {
+  proposal: ProposalWithDetails;
+  currentMemberId: string;
+  currentMemberJoinedAt: string;
+  householdId: string;
+}
+
+// Type badge config
+const TYPE_CONFIG = {
+  elect_admin: {
+    label: "Admin Election",
+    icon: Crown,
+    bg: "bg-accent-light",
+    text: "text-accent",
+    border: "border-accent/15",
+  },
+  remove_member: {
+    label: "Remove Member",
+    icon: UserMinus,
+    bg: "bg-highlight-light",
+    text: "text-highlight",
+    border: "border-highlight/15",
+  },
+  custom: {
+    label: "Custom Vote",
+    icon: Scales,
+    bg: "bg-primary-light",
+    text: "text-primary",
+    border: "border-primary/15",
+  },
+} as const;
+
+// Status badge config
+const STATUS_CONFIG = {
+  active: { label: "Active", bg: "bg-primary-light", text: "text-primary" },
+  passed: { label: "Passed", bg: "bg-success/10", text: "text-success" },
+  failed: { label: "Failed", bg: "bg-error-light", text: "text-error" },
+  expired: {
+    label: "Expired",
+    bg: "bg-surface-secondary",
+    text: "text-text-muted",
+  },
+} as const;
+
+function formatRelativeTime(isoString: string): string {
+  const now = Date.now();
+  const then = new Date(isoString).getTime();
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60000);
+  const diffHr = Math.floor(diffMs / 3600000);
+  const diffDay = Math.floor(diffMs / 86400000);
+
+  if (diffMin < 1) return "Just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay === 1) return "Yesterday";
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(isoString).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function useCountdown(deadline: string, isActive: boolean) {
+  const [timeLeft, setTimeLeft] = useState("");
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    function update() {
+      const now = Date.now();
+      const end = new Date(deadline).getTime();
+      const diff = end - now;
+
+      if (diff <= 0) {
+        setTimeLeft("Voting ended");
+        return;
+      }
+
+      const hours = Math.floor(diff / 3600000);
+      const minutes = Math.floor((diff % 3600000) / 60000);
+      const seconds = Math.floor((diff % 60000) / 1000);
+
+      if (hours > 24) {
+        const days = Math.floor(hours / 24);
+        setTimeLeft(`${days}d ${hours % 24}h left`);
+      } else if (hours > 0) {
+        setTimeLeft(`${hours}h ${minutes}m left`);
+      } else if (minutes > 0) {
+        setTimeLeft(`${minutes}m ${seconds}s left`);
+      } else {
+        setTimeLeft(`${seconds}s left`);
+      }
+    }
+
+    update();
+    const interval = setInterval(update, 1000);
+    return () => clearInterval(interval);
+  }, [deadline, isActive]);
+
+  return timeLeft;
+}
+
+export function ProposalCard({
+  proposal,
+  currentMemberId,
+  currentMemberJoinedAt,
+  householdId,
+}: ProposalCardProps) {
+  const queryClient = useQueryClient();
+  const isActive = proposal.status === "active";
+  const countdown = useCountdown(proposal.voting_deadline, isActive);
+
+  const typeConfig = TYPE_CONFIG[proposal.type];
+  const statusConfig = STATUS_CONFIG[proposal.status];
+  const TypeIcon = typeConfig.icon;
+
+  // Vote counts
+  const yesCount = proposal.votes.filter((v) => v.vote === "yes").length;
+  const noCount = proposal.votes.filter((v) => v.vote === "no").length;
+
+  // Current user's vote
+  const myVote = proposal.votes.find(
+    (v) => v.member_id === currentMemberId
+  )?.vote;
+
+  // Can the current user vote?
+  const joinedAfterProposal =
+    new Date(currentMemberJoinedAt) >= new Date(proposal.created_at);
+  const deadlinePassed = new Date(proposal.voting_deadline) <= new Date();
+  const canVote = isActive && !myVote && !joinedAfterProposal && !deadlinePassed;
+
+  const voteMutation = useMutation({
+    mutationFn: async (vote: "yes" | "no") => {
+      const formData = new FormData();
+      formData.set("proposalId", proposal.id);
+      formData.set("vote", vote);
+      return castVote(formData);
+    },
+    onSuccess: (result) => {
+      if (result.success) {
+        queryClient.invalidateQueries({
+          queryKey: ["proposals", householdId],
+        });
+      }
+    },
+  });
+
+  const voteError = voteMutation.data?.error;
+
+  return (
+    <div
+      className={`bg-white/60 backdrop-blur-sm rounded-xl border ${
+        isActive ? typeConfig.border : "border-border-light"
+      } p-5 shadow-sm`}
+    >
+      {/* Top row: type badge + status + time */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium ${typeConfig.bg} ${typeConfig.text}`}
+          >
+            <TypeIcon className="w-3.5 h-3.5" weight="fill" />
+            {typeConfig.label}
+          </span>
+          {!isActive && (
+            <span
+              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium ${statusConfig.bg} ${statusConfig.text}`}
+            >
+              {proposal.status === "passed" && (
+                <CheckCircle className="w-3 h-3" weight="fill" />
+              )}
+              {proposal.status === "failed" && (
+                <XCircle className="w-3 h-3" weight="fill" />
+              )}
+              {statusConfig.label}
+            </span>
+          )}
+        </div>
+        {isActive && (
+          <span className="inline-flex items-center gap-1 text-xs text-text-muted">
+            <Timer className="w-3.5 h-3.5" />
+            {countdown}
+          </span>
+        )}
+      </div>
+
+      {/* Title + description */}
+      <h3 className="text-sm font-semibold text-text-primary">
+        {proposal.title}
+      </h3>
+      {proposal.description && (
+        <p className="text-sm text-text-secondary mt-1 leading-relaxed">
+          {proposal.description}
+        </p>
+      )}
+
+      {/* Target member (if applicable) */}
+      {proposal.target_member && (
+        <p className="text-xs text-text-muted mt-2">
+          {proposal.type === "elect_admin" ? "Nominee: " : "Subject: "}
+          <span className="font-medium text-text-secondary">
+            {proposal.target_member.users.display_name}
+          </span>
+        </p>
+      )}
+
+      {/* Meta: creator + time */}
+      <p className="text-xs text-text-muted mt-2">
+        Proposed by {proposal.creator.users.display_name}{" "}
+        {formatRelativeTime(proposal.created_at)}
+      </p>
+
+      {/* Vote progress bar */}
+      <div className="mt-4">
+        <VoteProgressBar
+          yesCount={yesCount}
+          noCount={noCount}
+          eligibleVoterCount={proposal.eligible_voter_count}
+          participationThreshold={proposal.min_participation_threshold}
+        />
+      </div>
+
+      {/* Vote actions (only for active proposals) */}
+      {isActive && (
+        <div className="mt-4">
+          {voteError && (
+            <p className="text-xs text-error-text bg-error-light px-3 py-1.5 rounded-lg mb-2">
+              {voteError}
+            </p>
+          )}
+
+          {myVote ? (
+            <div className="flex items-center gap-2 text-xs text-text-muted">
+              <Check className="w-4 h-4 text-success" weight="bold" />
+              You voted{" "}
+              <span
+                className={`font-medium ${
+                  myVote === "yes" ? "text-success" : "text-error"
+                }`}
+              >
+                {myVote === "yes" ? "Yes" : "No"}
+              </span>
+            </div>
+          ) : joinedAfterProposal ? (
+            <p className="text-xs text-text-muted italic">
+              You joined after this proposal was created
+            </p>
+          ) : deadlinePassed ? (
+            <p className="text-xs text-text-muted italic">
+              The voting period has ended
+            </p>
+          ) : (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => voteMutation.mutate("yes")}
+                disabled={voteMutation.isPending}
+                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-success bg-success/10 hover:bg-success/20 rounded-lg transition-colors disabled:opacity-50"
+              >
+                {voteMutation.isPending ? (
+                  <SpinnerGap className="w-4 h-4 animate-spin" />
+                ) : (
+                  <CheckCircle className="w-4 h-4" weight="fill" />
+                )}
+                Yes
+              </button>
+              <button
+                onClick={() => voteMutation.mutate("no")}
+                disabled={voteMutation.isPending}
+                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-error bg-error-light hover:bg-error/20 rounded-lg transition-colors disabled:opacity-50"
+              >
+                {voteMutation.isPending ? (
+                  <SpinnerGap className="w-4 h-4 animate-spin" />
+                ) : (
+                  <XCircle className="w-4 h-4" weight="fill" />
+                )}
+                No
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/proposals/proposal-feed.tsx
+++ b/src/components/proposals/proposal-feed.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Scales, CaretDown, CaretUp } from "@phosphor-icons/react";
+import { useSupabase } from "@/hooks/use-supabase";
+import type { ProposalWithDetails } from "@/lib/proposals/queries";
+import type { HouseholdMemberWithUser } from "@/lib/household/members";
+import { ProposalCard } from "./proposal-card";
+import { CreateProposalForm } from "./create-proposal-form";
+
+interface ProposalFeedProps {
+  initialProposals: ProposalWithDetails[];
+  householdId: string;
+  currentMemberId: string;
+  currentMemberJoinedAt: string;
+  currentMemberRole: "admin" | "member";
+  members: HouseholdMemberWithUser[];
+}
+
+export function ProposalFeed({
+  initialProposals,
+  householdId,
+  currentMemberId,
+  currentMemberJoinedAt,
+  currentMemberRole,
+  members,
+}: ProposalFeedProps) {
+  const supabase = useSupabase();
+  const [showPast, setShowPast] = useState(false);
+
+  const { data: proposals } = useQuery({
+    queryKey: ["proposals", householdId],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("proposals")
+        .select(
+          `
+          *,
+          target_member:household_members!proposals_target_member_id_fkey(
+            id,
+            users!inner(display_name)
+          ),
+          creator:household_members!proposals_created_by_fkey(
+            id,
+            users!inner(display_name)
+          ),
+          votes(id, member_id, vote, voted_at)
+        `
+        )
+        .eq("household_id", householdId)
+        .order("created_at", { ascending: false });
+
+      if (error) return [];
+      return data as unknown as ProposalWithDetails[];
+    },
+    initialData: initialProposals,
+    staleTime: 0,
+  });
+
+  const activeProposals = proposals.filter((p) => p.status === "active");
+  const pastProposals = proposals.filter((p) => p.status !== "active");
+
+  return (
+    <div className="space-y-6">
+      {/* Create button */}
+      <CreateProposalForm
+        householdId={householdId}
+        members={members}
+        currentMemberRole={currentMemberRole}
+      />
+
+      {/* Active Proposals */}
+      {activeProposals.length > 0 ? (
+        <div className="space-y-3">
+          <h2 className="text-sm font-semibold text-text-primary flex items-center gap-2">
+            <Scales className="w-4 h-4 text-primary" />
+            Active Proposals ({activeProposals.length})
+          </h2>
+          {activeProposals.map((proposal) => (
+            <ProposalCard
+              key={proposal.id}
+              proposal={proposal}
+              currentMemberId={currentMemberId}
+              currentMemberJoinedAt={currentMemberJoinedAt}
+              householdId={householdId}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Scales className="w-12 h-12 text-text-muted mb-3" />
+          <p className="text-text-secondary font-medium">
+            No active proposals
+          </p>
+          <p className="text-sm text-text-muted mt-1">
+            Create a proposal to start a household vote
+          </p>
+        </div>
+      )}
+
+      {/* Past Proposals (collapsible) */}
+      {pastProposals.length > 0 && (
+        <div>
+          <button
+            onClick={() => setShowPast(!showPast)}
+            className="flex items-center gap-2 text-sm font-medium text-text-secondary hover:text-text-primary transition-colors"
+          >
+            {showPast ? (
+              <CaretUp className="w-4 h-4" />
+            ) : (
+              <CaretDown className="w-4 h-4" />
+            )}
+            Past Proposals ({pastProposals.length})
+          </button>
+
+          {showPast && (
+            <div className="space-y-3 mt-3">
+              {pastProposals.map((proposal) => (
+                <ProposalCard
+                  key={proposal.id}
+                  proposal={proposal}
+                  currentMemberId={currentMemberId}
+                  currentMemberJoinedAt={currentMemberJoinedAt}
+                  householdId={householdId}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/proposals/vote-progress-bar.tsx
+++ b/src/components/proposals/vote-progress-bar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+interface VoteProgressBarProps {
+  yesCount: number;
+  noCount: number;
+  eligibleVoterCount: number;
+  participationThreshold: number;
+}
+
+export function VoteProgressBar({
+  yesCount,
+  noCount,
+  eligibleVoterCount,
+  participationThreshold,
+}: VoteProgressBarProps) {
+  const totalVotes = yesCount + noCount;
+  const remaining = eligibleVoterCount - totalVotes;
+
+  const yesPct =
+    eligibleVoterCount > 0 ? (yesCount / eligibleVoterCount) * 100 : 0;
+  const noPct =
+    eligibleVoterCount > 0 ? (noCount / eligibleVoterCount) * 100 : 0;
+  const remainPct =
+    eligibleVoterCount > 0 ? (remaining / eligibleVoterCount) * 100 : 100;
+
+  // Quorum line position
+  const quorumPct = participationThreshold * 100;
+
+  return (
+    <div className="space-y-1.5">
+      {/* Bar */}
+      <div className="relative h-3 rounded-full bg-surface-secondary overflow-hidden">
+        {/* Yes */}
+        {yesPct > 0 && (
+          <div
+            className="absolute inset-y-0 left-0 bg-success rounded-l-full transition-all duration-500"
+            style={{ width: `${yesPct}%` }}
+          />
+        )}
+        {/* No */}
+        {noPct > 0 && (
+          <div
+            className="absolute inset-y-0 bg-error transition-all duration-500"
+            style={{ left: `${yesPct}%`, width: `${noPct}%` }}
+          />
+        )}
+        {/* Quorum indicator line */}
+        <div
+          className="absolute inset-y-0 w-0.5 bg-text-muted/60 z-10"
+          style={{ left: `${quorumPct}%` }}
+          title={`Quorum: ${Math.round(quorumPct)}% participation needed`}
+        />
+      </div>
+
+      {/* Labels */}
+      <div className="flex items-center gap-3 text-xs text-text-muted">
+        <span className="flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full bg-success inline-block" />
+          {yesCount} Yes
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full bg-error inline-block" />
+          {noCount} No
+        </span>
+        {remaining > 0 && (
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-surface-secondary inline-block border border-border-light" />
+            {remaining} Remaining
+          </span>
+        )}
+        <span className="ml-auto text-text-muted/60">
+          Quorum: {Math.round(quorumPct)}%
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/proposals/actions.ts
+++ b/src/lib/proposals/actions.ts
@@ -1,0 +1,294 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { getCurrentMembership } from "@/lib/household/queries";
+import { createProposalSchema, castVoteSchema } from "./validation";
+import {
+  evaluateProposalOutcome,
+  handleElectAdmin,
+  handleRemoveMember,
+} from "./resolution";
+
+type ActionResult = { error?: string; success?: boolean };
+
+// ---- CREATE PROPOSAL ----
+export async function createProposal(
+  formData: FormData
+): Promise<ActionResult> {
+  const parsed = createProposalSchema.safeParse({
+    type: formData.get("type"),
+    title: formData.get("title"),
+    description: formData.get("description"),
+    targetMemberId: formData.get("targetMemberId") || null,
+    durationHours: formData.get("durationHours") || undefined,
+  });
+
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0].message };
+  }
+
+  const membership = await getCurrentMembership();
+  if (!membership) return { error: "Not authenticated" };
+
+  const supabase = await createClient();
+
+  // Fetch household config
+  const { data: household } = await supabase
+    .from("households")
+    .select("min_vote_participation, default_vote_duration_hours")
+    .eq("id", membership.householdId)
+    .single();
+
+  if (!household) return { error: "Household not found" };
+
+  // D11: Only one active admin election at a time
+  if (parsed.data.type === "elect_admin") {
+    const { data: activeElection } = await supabase
+      .from("proposals")
+      .select("id")
+      .eq("household_id", membership.householdId)
+      .eq("type", "elect_admin")
+      .eq("status", "active")
+      .maybeSingle();
+
+    if (activeElection) {
+      return {
+        error: "There is already an active admin election. Please wait for it to resolve.",
+      };
+    }
+  }
+
+  // Validate target member for elect_admin and remove_member
+  if (parsed.data.type === "elect_admin" && parsed.data.targetMemberId) {
+    const { data: target } = await supabase
+      .from("household_members")
+      .select("id, role")
+      .eq("id", parsed.data.targetMemberId)
+      .eq("household_id", membership.householdId)
+      .is("left_at", null)
+      .single();
+
+    if (!target) return { error: "Target member not found" };
+    if (target.role === "admin") {
+      return { error: "This member is already the admin" };
+    }
+  }
+
+  if (parsed.data.type === "remove_member" && parsed.data.targetMemberId) {
+    const { data: target } = await supabase
+      .from("household_members")
+      .select("id")
+      .eq("id", parsed.data.targetMemberId)
+      .eq("household_id", membership.householdId)
+      .is("left_at", null)
+      .single();
+
+    if (!target) return { error: "Target member not found" };
+  }
+
+  // Snapshot eligible voter count (active members)
+  const { count: eligibleCount } = await supabase
+    .from("household_members")
+    .select("id", { count: "exact", head: true })
+    .eq("household_id", membership.householdId)
+    .is("left_at", null);
+
+  const eligibleVoterCount = eligibleCount ?? 1;
+
+  // Compute voting deadline
+  const durationHours =
+    parsed.data.durationHours ?? household.default_vote_duration_hours;
+  const deadline = new Date(
+    Date.now() + durationHours * 60 * 60 * 1000
+  ).toISOString();
+
+  // Insert proposal
+  const { error: insertError } = await supabase.from("proposals").insert({
+    household_id: membership.householdId,
+    type: parsed.data.type,
+    title: parsed.data.title,
+    description: parsed.data.description || null,
+    target_member_id: parsed.data.targetMemberId ?? null,
+    created_by: membership.memberId,
+    eligible_voter_count: eligibleVoterCount,
+    min_participation_threshold: household.min_vote_participation,
+    voting_deadline: deadline,
+  });
+
+  if (insertError) {
+    // D11 enforcement via partial unique index
+    if (insertError.code === "23505") {
+      return {
+        error:
+          "There is already an active admin election. Please wait for it to resolve.",
+      };
+    }
+    return { error: "Failed to create proposal. Please try again." };
+  }
+
+  return { success: true };
+}
+
+// ---- CAST VOTE ----
+export async function castVote(formData: FormData): Promise<ActionResult> {
+  const parsed = castVoteSchema.safeParse({
+    proposalId: formData.get("proposalId"),
+    vote: formData.get("vote"),
+  });
+
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0].message };
+  }
+
+  const membership = await getCurrentMembership();
+  if (!membership) return { error: "Not authenticated" };
+
+  const supabase = await createClient();
+
+  // Fetch proposal
+  const { data: proposal } = await supabase
+    .from("proposals")
+    .select("*")
+    .eq("id", parsed.data.proposalId)
+    .eq("household_id", membership.householdId)
+    .single();
+
+  if (!proposal) return { error: "Proposal not found" };
+  if (proposal.status !== "active") {
+    return { error: "This proposal is no longer active" };
+  }
+
+  // Check deadline
+  if (new Date(proposal.voting_deadline) <= new Date()) {
+    return { error: "The voting period has ended" };
+  }
+
+  // D30: Members who joined after proposal creation cannot vote
+  const { data: member } = await supabase
+    .from("household_members")
+    .select("joined_at")
+    .eq("id", membership.memberId)
+    .single();
+
+  if (member && new Date(member.joined_at) >= new Date(proposal.created_at)) {
+    return {
+      error: "You joined after this proposal was created and cannot vote on it",
+    };
+  }
+
+  // Check if already voted
+  const { data: existingVote } = await supabase
+    .from("votes")
+    .select("id")
+    .eq("proposal_id", parsed.data.proposalId)
+    .eq("member_id", membership.memberId)
+    .maybeSingle();
+
+  if (existingVote) {
+    return { error: "You have already voted on this proposal" };
+  }
+
+  // Insert vote
+  const { error: voteError } = await supabase.from("votes").insert({
+    proposal_id: parsed.data.proposalId,
+    member_id: membership.memberId,
+    vote: parsed.data.vote,
+  });
+
+  if (voteError) {
+    // Unique constraint violation
+    if (voteError.code === "23505") {
+      return { error: "You have already voted on this proposal" };
+    }
+    return { error: "Failed to cast vote. Please try again." };
+  }
+
+  // Early resolution: if all eligible voters have voted
+  const { count: voteCount } = await supabase
+    .from("votes")
+    .select("id", { count: "exact", head: true })
+    .eq("proposal_id", parsed.data.proposalId);
+
+  if (voteCount && voteCount >= proposal.eligible_voter_count) {
+    await resolveProposal(parsed.data.proposalId);
+  }
+
+  return { success: true };
+}
+
+// ---- RESOLVE PROPOSAL (internal) ----
+async function resolveProposal(proposalId: string): Promise<void> {
+  const supabase = await createClient();
+
+  // Fetch proposal (guard: must still be active)
+  const { data: proposal } = await supabase
+    .from("proposals")
+    .select("*")
+    .eq("id", proposalId)
+    .eq("status", "active")
+    .single();
+
+  if (!proposal) return; // Already resolved by concurrent request
+
+  // Fetch all votes
+  const { data: votes } = await supabase
+    .from("votes")
+    .select("vote")
+    .eq("proposal_id", proposalId);
+
+  if (!votes) return;
+
+  // Evaluate outcome
+  const outcome = evaluateProposalOutcome(
+    proposal.eligible_voter_count,
+    proposal.min_participation_threshold,
+    votes as { vote: "yes" | "no" }[]
+  );
+
+  // Update proposal status (race-condition guard: only update if still active)
+  const { data: updated } = await supabase
+    .from("proposals")
+    .update({
+      status: outcome,
+      resolved_at: new Date().toISOString(),
+    })
+    .eq("id", proposalId)
+    .eq("status", "active")
+    .select("id")
+    .single();
+
+  // If no rows updated, another request already resolved it
+  if (!updated) return;
+
+  // Execute side effects if passed
+  if (outcome === "passed") {
+    if (proposal.type === "elect_admin") {
+      await handleElectAdmin(supabase, proposal);
+    } else if (proposal.type === "remove_member") {
+      await handleRemoveMember(supabase, proposal);
+    }
+  }
+}
+
+// ---- EXPIRE PROPOSALS (called on page load) ----
+export async function expireProposals(): Promise<void> {
+  const membership = await getCurrentMembership();
+  if (!membership) return;
+
+  const supabase = await createClient();
+
+  // Find all overdue active proposals in this household
+  const { data: overdueProposals } = await supabase
+    .from("proposals")
+    .select("id")
+    .eq("household_id", membership.householdId)
+    .eq("status", "active")
+    .lte("voting_deadline", new Date().toISOString());
+
+  if (!overdueProposals || overdueProposals.length === 0) return;
+
+  // Resolve each one
+  for (const p of overdueProposals) {
+    await resolveProposal(p.id);
+  }
+}

--- a/src/lib/proposals/queries.ts
+++ b/src/lib/proposals/queries.ts
@@ -1,0 +1,62 @@
+import { createClient } from "@/lib/supabase/server";
+
+export type ProposalWithDetails = {
+  id: string;
+  household_id: string;
+  type: "elect_admin" | "remove_member" | "custom";
+  title: string;
+  description: string | null;
+  target_member_id: string | null;
+  created_by: string;
+  status: "active" | "passed" | "failed" | "expired";
+  eligible_voter_count: number;
+  min_participation_threshold: number;
+  voting_deadline: string;
+  resolved_at: string | null;
+  created_at: string;
+  target_member: {
+    id: string;
+    users: { display_name: string };
+  } | null;
+  creator: {
+    id: string;
+    users: { display_name: string };
+  };
+  votes: {
+    id: string;
+    member_id: string;
+    vote: "yes" | "no";
+    voted_at: string;
+  }[];
+};
+
+/**
+ * Fetch all proposals for a household, with creator/target member names and votes.
+ */
+export async function getProposals(
+  householdId: string
+): Promise<ProposalWithDetails[]> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("proposals")
+    .select(
+      `
+      *,
+      target_member:household_members!proposals_target_member_id_fkey(
+        id,
+        users!inner(display_name)
+      ),
+      creator:household_members!proposals_created_by_fkey(
+        id,
+        users!inner(display_name)
+      ),
+      votes(id, member_id, vote, voted_at)
+    `
+    )
+    .eq("household_id", householdId)
+    .order("created_at", { ascending: false });
+
+  if (error) return [];
+  return data as unknown as ProposalWithDetails[];
+}

--- a/src/lib/proposals/resolution.test.ts
+++ b/src/lib/proposals/resolution.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { evaluateProposalOutcome } from "./resolution";
+
+describe("evaluateProposalOutcome", () => {
+  // D8: Quorum check
+  describe("quorum (D8)", () => {
+    it("returns 'expired' when quorum is not met", () => {
+      // 4 eligible voters, 50% threshold, only 1 vote
+      const result = evaluateProposalOutcome(4, 0.5, [{ vote: "yes" }]);
+      expect(result).toBe("expired");
+    });
+
+    it("meets quorum when participation equals threshold exactly", () => {
+      // 4 eligible voters, 50% threshold, 2 votes (50%)
+      const result = evaluateProposalOutcome(4, 0.5, [
+        { vote: "yes" },
+        { vote: "yes" },
+      ]);
+      expect(result).toBe("passed");
+    });
+
+    it("meets quorum when participation exceeds threshold", () => {
+      // 4 eligible voters, 50% threshold, 3 votes (75%)
+      const result = evaluateProposalOutcome(4, 0.5, [
+        { vote: "yes" },
+        { vote: "yes" },
+        { vote: "no" },
+      ]);
+      expect(result).toBe("passed");
+    });
+
+    it("returns 'expired' with zero voters", () => {
+      const result = evaluateProposalOutcome(0, 0.5, []);
+      expect(result).toBe("expired");
+    });
+
+    it("returns 'expired' with no votes even if threshold is 0", () => {
+      // 0% threshold still requires at least some participation for a result
+      // With 0 votes and 0 threshold, participation = 0/4 = 0 which is >= 0
+      // Actually 0 >= 0 is true, so quorum is met. With no votes, yes=0, no=0.
+      // 0 > 0 is false, so result = "failed"
+      const result = evaluateProposalOutcome(4, 0, []);
+      expect(result).toBe("failed");
+    });
+  });
+
+  // D9: Strict majority
+  describe("strict majority (D9)", () => {
+    it("returns 'passed' when yes > no", () => {
+      const result = evaluateProposalOutcome(3, 0.5, [
+        { vote: "yes" },
+        { vote: "yes" },
+        { vote: "no" },
+      ]);
+      expect(result).toBe("passed");
+    });
+
+    it("returns 'failed' when yes === no (tie)", () => {
+      const result = evaluateProposalOutcome(4, 0.5, [
+        { vote: "yes" },
+        { vote: "yes" },
+        { vote: "no" },
+        { vote: "no" },
+      ]);
+      expect(result).toBe("failed");
+    });
+
+    it("returns 'failed' when no > yes", () => {
+      const result = evaluateProposalOutcome(3, 0.5, [
+        { vote: "yes" },
+        { vote: "no" },
+        { vote: "no" },
+      ]);
+      expect(result).toBe("failed");
+    });
+
+    it("returns 'passed' with unanimous yes", () => {
+      const result = evaluateProposalOutcome(3, 0.5, [
+        { vote: "yes" },
+        { vote: "yes" },
+        { vote: "yes" },
+      ]);
+      expect(result).toBe("passed");
+    });
+
+    it("returns 'failed' with unanimous no", () => {
+      const result = evaluateProposalOutcome(3, 0.5, [
+        { vote: "no" },
+        { vote: "no" },
+        { vote: "no" },
+      ]);
+      expect(result).toBe("failed");
+    });
+  });
+
+  // Edge cases
+  describe("edge cases", () => {
+    it("handles single voter household", () => {
+      // 1 eligible, 50% threshold, 1 yes vote
+      const result = evaluateProposalOutcome(1, 0.5, [{ vote: "yes" }]);
+      expect(result).toBe("passed");
+    });
+
+    it("handles single voter voting no", () => {
+      const result = evaluateProposalOutcome(1, 0.5, [{ vote: "no" }]);
+      expect(result).toBe("failed");
+    });
+
+    it("handles high threshold (100%)", () => {
+      // 3 eligible, 100% threshold, only 2 voted
+      const result = evaluateProposalOutcome(3, 1.0, [
+        { vote: "yes" },
+        { vote: "yes" },
+      ]);
+      expect(result).toBe("expired");
+    });
+
+    it("passes with 100% threshold when all vote", () => {
+      const result = evaluateProposalOutcome(3, 1.0, [
+        { vote: "yes" },
+        { vote: "yes" },
+        { vote: "no" },
+      ]);
+      expect(result).toBe("passed");
+    });
+
+    it("handles large household", () => {
+      const votes = Array.from({ length: 6 }, () => ({ vote: "yes" as const }));
+      votes.push(
+        ...Array.from({ length: 4 }, () => ({ vote: "no" as const }))
+      );
+      // 10 eligible, 50% threshold, all 10 voted, 6 yes / 4 no
+      const result = evaluateProposalOutcome(10, 0.5, votes);
+      expect(result).toBe("passed");
+    });
+
+    it("expired when exactly at threshold boundary but quorum not quite met", () => {
+      // 5 eligible, 50% threshold, 2 votes (40% < 50%)
+      const result = evaluateProposalOutcome(5, 0.5, [
+        { vote: "yes" },
+        { vote: "yes" },
+      ]);
+      expect(result).toBe("expired");
+    });
+  });
+});

--- a/src/lib/proposals/resolution.ts
+++ b/src/lib/proposals/resolution.ts
@@ -1,0 +1,177 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database.types";
+import type { ProposalStatus, VoteChoice } from "@/types";
+
+// ---- Pure outcome evaluation (no DB) ----
+
+export type ProposalOutcome = "passed" | "failed" | "expired";
+
+/**
+ * Evaluate the outcome of a proposal based on votes cast.
+ *
+ * Business rules:
+ * - D8: Quorum = totalVotes / eligibleVoterCount >= threshold
+ * - D9: Majority = yesCount > noCount (strict majority of those who voted)
+ * - If quorum not met → "expired"
+ */
+export function evaluateProposalOutcome(
+  eligibleVoterCount: number,
+  threshold: number,
+  votes: { vote: VoteChoice }[]
+): ProposalOutcome {
+  const totalVotes = votes.length;
+  const yesCount = votes.filter((v) => v.vote === "yes").length;
+  const noCount = votes.filter((v) => v.vote === "no").length;
+
+  // Check quorum (D8)
+  const participation = eligibleVoterCount > 0 ? totalVotes / eligibleVoterCount : 0;
+  if (participation < threshold) {
+    return "expired";
+  }
+
+  // Strict majority (D9): yes must be strictly greater than no
+  if (yesCount > noCount) {
+    return "passed";
+  }
+
+  return "failed";
+}
+
+// ---- Side effects for passed proposals ----
+
+type Supabase = SupabaseClient<Database>;
+
+interface ProposalData {
+  id: string;
+  household_id: string;
+  type: string;
+  target_member_id: string | null;
+}
+
+/**
+ * Handle side effects when an "elect_admin" proposal passes.
+ *
+ * 1. Close current admin's admin_history record
+ * 2. Demote current admin → role = "member"
+ * 3. Promote target → role = "admin"
+ * 4. Insert new admin_history record (reason = "elected")
+ */
+export async function handleElectAdmin(
+  supabase: Supabase,
+  proposal: ProposalData
+): Promise<void> {
+  if (!proposal.target_member_id) return;
+
+  // Find the current admin
+  const { data: currentAdmin } = await supabase
+    .from("household_members")
+    .select("id")
+    .eq("household_id", proposal.household_id)
+    .eq("role", "admin")
+    .is("left_at", null)
+    .single();
+
+  if (currentAdmin) {
+    // Close their admin_history record
+    await supabase
+      .from("admin_history")
+      .update({ ended_at: new Date().toISOString() })
+      .eq("household_id", proposal.household_id)
+      .eq("member_id", currentAdmin.id)
+      .is("ended_at", null);
+
+    // Demote to member
+    await supabase
+      .from("household_members")
+      .update({ role: "member" })
+      .eq("id", currentAdmin.id);
+  }
+
+  // Promote target to admin
+  await supabase
+    .from("household_members")
+    .update({ role: "admin" })
+    .eq("id", proposal.target_member_id);
+
+  // Insert new admin_history record
+  await supabase.from("admin_history").insert({
+    household_id: proposal.household_id,
+    member_id: proposal.target_member_id,
+    reason: "elected",
+    proposal_id: proposal.id,
+  });
+}
+
+/**
+ * Handle side effects when a "remove_member" proposal passes.
+ *
+ * 1. Set left_at on target member
+ * 2. Unassign their pending chores (D29)
+ * 3. If target was admin → auto-promote longest-tenured member (D12)
+ */
+export async function handleRemoveMember(
+  supabase: Supabase,
+  proposal: ProposalData
+): Promise<void> {
+  if (!proposal.target_member_id) return;
+
+  // Check if target is admin
+  const { data: targetMember } = await supabase
+    .from("household_members")
+    .select("id, role")
+    .eq("id", proposal.target_member_id)
+    .single();
+
+  const wasAdmin = targetMember?.role === "admin";
+
+  // 1. Set left_at on target member
+  await supabase
+    .from("household_members")
+    .update({ left_at: new Date().toISOString() })
+    .eq("id", proposal.target_member_id);
+
+  // 2. Unassign their pending chores (D29)
+  await supabase
+    .from("chore_instances")
+    .update({ assigned_to: null })
+    .eq("assigned_to", proposal.target_member_id)
+    .eq("status", "pending");
+
+  // 3. If target was admin, auto-promote (D12)
+  if (wasAdmin) {
+    // Close their admin_history record
+    await supabase
+      .from("admin_history")
+      .update({ ended_at: new Date().toISOString() })
+      .eq("household_id", proposal.household_id)
+      .eq("member_id", proposal.target_member_id)
+      .is("ended_at", null);
+
+    // Find longest-tenured remaining active member (tiebreaker: smallest UUID)
+    const { data: nextAdmin } = await supabase
+      .from("household_members")
+      .select("id")
+      .eq("household_id", proposal.household_id)
+      .is("left_at", null)
+      .neq("id", proposal.target_member_id)
+      .order("joined_at", { ascending: true })
+      .order("id", { ascending: true })
+      .limit(1)
+      .single();
+
+    if (nextAdmin) {
+      // Promote them
+      await supabase
+        .from("household_members")
+        .update({ role: "admin" })
+        .eq("id", nextAdmin.id);
+
+      // Insert admin_history
+      await supabase.from("admin_history").insert({
+        household_id: proposal.household_id,
+        member_id: nextAdmin.id,
+        reason: "auto_promoted",
+      });
+    }
+  }
+}

--- a/src/lib/proposals/validation.ts
+++ b/src/lib/proposals/validation.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const PROPOSAL_TYPES = ["elect_admin", "remove_member", "custom"] as const;
+
+export const createProposalSchema = z
+  .object({
+    type: z.enum(PROPOSAL_TYPES),
+    title: z
+      .string()
+      .min(1, "Title is required")
+      .max(200, "Title too long"),
+    description: z
+      .string()
+      .max(2000, "Description too long")
+      .optional()
+      .or(z.literal("")),
+    targetMemberId: z.string().uuid("Invalid member").optional().nullable(),
+    durationHours: z.coerce
+      .number()
+      .int()
+      .min(1, "Duration must be at least 1 hour")
+      .max(168, "Duration cannot exceed 7 days")
+      .optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.type === "elect_admin" || data.type === "remove_member") {
+        return !!data.targetMemberId;
+      }
+      return true;
+    },
+    {
+      message: "Please select a target member",
+      path: ["targetMemberId"],
+    }
+  );
+
+export const castVoteSchema = z.object({
+  proposalId: z.string().uuid("Invalid proposal"),
+  vote: z.enum(["yes", "no"]),
+});
+
+export type CreateProposalInput = z.infer<typeof createProposalSchema>;
+export type CastVoteInput = z.infer<typeof castVoteSchema>;


### PR DESCRIPTION
## Summary
- Implement the complete household governance system — the last remaining feature in NestSync
- Add proposal creation (elect_admin, remove_member, custom), vote casting with business rule enforcement (D8 quorum, D9 strict majority, D11 one active election, D30 mid-vote joiner protection), and automatic resolution with side effects (admin transition, member removal with auto-promote D12)
- Full UI: ProposalFeed, ProposalCard with live countdown timer, VoteProgressBar with quorum indicator, CreateProposalForm with type selector and conditional target member dropdown
- Enable "Votes" in sidebar nav — all features now active (no more "Soon" badges)

## New Files (10)
- `src/lib/proposals/validation.ts` — Zod schemas
- `src/lib/proposals/resolution.ts` — Pure outcome evaluation + side effects
- `src/lib/proposals/resolution.test.ts` — 16 tests for resolution logic
- `src/lib/proposals/queries.ts` — getProposals with joined data
- `src/lib/proposals/actions.ts` — createProposal, castVote, expireProposals
- `src/components/proposals/vote-progress-bar.tsx`
- `src/components/proposals/proposal-card.tsx`
- `src/components/proposals/create-proposal-form.tsx`
- `src/components/proposals/proposal-feed.tsx`
- `src/app/(dashboard)/dashboard/votes/page.tsx`

## Test plan
- [ ] 484 tests pass (`npx vitest run`)
- [ ] Build succeeds (`npx next build`)
- [ ] Votes link appears in sidebar, navigates to `/dashboard/votes`
- [ ] Create custom proposal → appears in active section with countdown
- [ ] Cast vote → progress bar updates, vote buttons disabled with checkmark
- [ ] Early resolution → all members vote → proposal resolves immediately
- [ ] Expired proposal → visit page after deadline → shows "expired"
- [ ] D30 → member who joins after proposal cannot vote
- [ ] D11 → creating second elect_admin while one is active → error

🤖 Generated with [Claude Code](https://claude.com/claude-code)