### PR TITLE
Redesign sidebar and top bar with glassmorphism

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,6 +91,7 @@
   --font-sans: var(--font-inter);
   --font-heading: var(--font-nunito);
   --font-logo: var(--font-satisfy);
+  --font-handwritten: var(--font-handwritten);
   --font-mono: var(--font-geist-mono);
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, Nunito, Satisfy, Geist_Mono } from "next/font/google";
+import { Inter, Nunito, Satisfy, Patrick_Hand, Geist_Mono } from "next/font/google";
 import { Providers } from "./providers";
 import "./globals.css";
 
@@ -16,6 +16,12 @@ const nunito = Nunito({
 
 const satisfy = Satisfy({
   variable: "--font-satisfy",
+  subsets: ["latin"],
+  weight: "400",
+});
+
+const patrickHand = Patrick_Hand({
+  variable: "--font-handwritten",
   subsets: ["latin"],
   weight: "400",
 });
@@ -38,7 +44,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${inter.variable} ${nunito.variable} ${satisfy.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${nunito.variable} ${satisfy.variable} ${patrickHand.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>{children}</Providers>
       </body>

--- a/src/components/dashboard/dashboard-shell.test.tsx
+++ b/src/components/dashboard/dashboard-shell.test.tsx
@@ -3,6 +3,22 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DashboardShell } from "./dashboard-shell";
 
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => {
+    const React = require("react");
+    return React.createElement("a", { href, ...props }, children);
+  },
+}));
+
 // Mock sub-components to isolate testing
 vi.mock("./sidebar-nav", () => ({
   SidebarNav: ({ onNavigate }: { onNavigate: () => void }) => (
@@ -14,16 +30,13 @@ vi.mock("./sidebar-nav", () => ({
 
 vi.mock("./top-bar", () => ({
   TopBar: ({
-    householdName,
     userName,
     onMenuToggle,
   }: {
-    householdName: string;
     userName: string;
     onMenuToggle: () => void;
   }) => (
     <div data-testid="top-bar">
-      <span>{householdName}</span>
       <span>{userName}</span>
       <button onClick={onMenuToggle} aria-label="toggle menu">
         Menu

--- a/src/components/dashboard/dashboard-shell.tsx
+++ b/src/components/dashboard/dashboard-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { X } from "@phosphor-icons/react";
 import { SidebarNav } from "./sidebar-nav";
 import { TopBar } from "./top-bar";
@@ -33,33 +34,38 @@ export function DashboardShell({
 
       {/* Sidebar */}
       <aside
-        className={`fixed inset-y-0 left-0 z-50 w-64 shrink-0 bg-surface/90 backdrop-blur-sm border-r border-border-light transform transition-transform lg:translate-x-0 lg:sticky lg:top-0 lg:h-screen lg:z-auto ${
+        className={`fixed inset-y-0 left-0 z-50 w-64 shrink-0 bg-surface/70 backdrop-blur-md border border-border-light transform transition-transform lg:translate-x-0 lg:sticky lg:top-0 lg:z-auto lg:rounded-2xl lg:m-3 lg:h-[calc(100vh-1.5rem)] lg:shadow-lg ${
           sidebarOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
-        <div className="flex flex-col h-full lg:h-screen">
-          {/* Sidebar header */}
-          <div className="h-16 flex items-center justify-between px-4 border-b border-border-light">
-            <div className="flex items-center gap-2">
+        <div className="flex flex-col h-full">
+          {/* Sidebar header: logo + household */}
+          <div className="px-4 pt-5 pb-4 border-b border-border-light/60">
+            <div className="flex items-center justify-between">
               <span className="font-logo text-2xl text-primary">NestSync</span>
+              <button
+                onClick={() => setSidebarOpen(false)}
+                className="lg:hidden p-1 rounded text-text-muted hover:text-text-secondary"
+                aria-label="Close sidebar"
+              >
+                <X className="w-5 h-5" />
+              </button>
             </div>
-            <button
-              onClick={() => setSidebarOpen(false)}
-              className="lg:hidden p-1 rounded text-text-muted hover:text-text-secondary"
-              aria-label="Close sidebar"
-            >
-              <X className="w-5 h-5" />
-            </button>
-          </div>
-
-          {/* Household name */}
-          <div className="px-4 py-3 border-b border-border-light">
-            <p className="text-xs text-text-muted uppercase tracking-wider font-medium">
+            <p className="text-[10px] uppercase tracking-widest text-text-muted font-medium mt-3">
               Household
             </p>
-            <p className="text-sm font-medium text-text-primary truncate mt-0.5">
+            <Link
+              href="/dashboard/household"
+              onClick={() => setSidebarOpen(false)}
+              className="block truncate mt-0.5 hover:opacity-80 transition-opacity"
+              style={{
+                fontFamily: "var(--font-handwritten)",
+                color: "#7A9478",
+                fontSize: "1.35rem",
+              }}
+            >
               {household.name}
-            </p>
+            </Link>
           </div>
 
           {/* Navigation */}
@@ -68,7 +74,7 @@ export function DashboardShell({
           </div>
 
           {/* Sidebar footer */}
-          <div className="px-4 py-3 border-t border-border-light">
+          <div className="px-4 py-3 border-t border-border-light/60">
             <p className="text-xs text-text-muted truncate">
               {user.display_name} ·{" "}
               {membership.role === "admin" ? "Admin" : "Member"}
@@ -80,7 +86,6 @@ export function DashboardShell({
       {/* Main content */}
       <div className="flex-1 min-w-0">
         <TopBar
-          householdName={household.name}
           inviteCode={household.invite_code}
           userName={user.display_name}
           avatarUrl={user.avatar_url}

--- a/src/components/dashboard/sidebar-nav.test.tsx
+++ b/src/components/dashboard/sidebar-nav.test.tsx
@@ -28,23 +28,24 @@ describe("SidebarNav", () => {
   it("renders all nav items", () => {
     mockPathname.mockReturnValue("/dashboard");
     render(<SidebarNav />);
-    expect(screen.getByText("Home")).toBeInTheDocument();
     expect(screen.getByText("My Page")).toBeInTheDocument();
-    expect(screen.getByText("Household")).toBeInTheDocument();
     expect(screen.getByText("Calendar")).toBeInTheDocument();
     expect(screen.getByText("Feed")).toBeInTheDocument();
     expect(screen.getByText("Votes")).toBeInTheDocument();
   });
 
+  it("does not render Home or Household nav items", () => {
+    mockPathname.mockReturnValue("/dashboard");
+    render(<SidebarNav />);
+    expect(screen.queryByText("Home")).toBeNull();
+    expect(screen.queryByText("Household")).toBeNull();
+  });
+
   it("renders all items as links", () => {
     mockPathname.mockReturnValue("/dashboard");
     render(<SidebarNav />);
-    const homeLink = screen.getByText("Home").closest("a");
-    expect(homeLink).toHaveAttribute("href", "/dashboard");
     const myPageLink = screen.getByText("My Page").closest("a");
     expect(myPageLink).toHaveAttribute("href", "/dashboard/my");
-    const householdLink = screen.getByText("Household").closest("a");
-    expect(householdLink).toHaveAttribute("href", "/dashboard/household");
     const calendarLink = screen.getByText("Calendar").closest("a");
     expect(calendarLink).toHaveAttribute("href", "/dashboard/calendar");
     const votesLink = screen.getByText("Votes").closest("a");
@@ -57,20 +58,11 @@ describe("SidebarNav", () => {
     expect(screen.queryByText("Soon")).toBeNull();
   });
 
-  it("highlights Home when on /dashboard", () => {
-    mockPathname.mockReturnValue("/dashboard");
-    render(<SidebarNav />);
-    const homeLink = screen.getByText("Home").closest("a");
-    expect(homeLink?.className).toContain("bg-sage-medium");
-  });
-
   it("highlights My Page when on /dashboard/my", () => {
     mockPathname.mockReturnValue("/dashboard/my");
     render(<SidebarNav />);
     const myPageLink = screen.getByText("My Page").closest("a");
     expect(myPageLink?.className).toContain("bg-sage-medium");
-    const homeLink = screen.getByText("Home").closest("a");
-    expect(homeLink?.className).not.toContain("bg-sage-medium");
   });
 
   it("highlights Calendar when on /dashboard/calendar", () => {
@@ -84,7 +76,7 @@ describe("SidebarNav", () => {
     mockPathname.mockReturnValue("/dashboard");
     const onNavigate = vi.fn();
     render(<SidebarNav onNavigate={onNavigate} />);
-    const homeLink = screen.getByText("Home").closest("a");
-    expect(homeLink).toHaveAttribute("href", "/dashboard");
+    const myPageLink = screen.getByText("My Page").closest("a");
+    expect(myPageLink).toHaveAttribute("href", "/dashboard/my");
   });
 });

--- a/src/components/dashboard/sidebar-nav.tsx
+++ b/src/components/dashboard/sidebar-nav.tsx
@@ -4,18 +4,14 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { Icon } from "@phosphor-icons/react";
 import {
-  House,
   UserCircle,
-  UsersThree,
   CalendarDots,
   Megaphone,
   Scales,
 } from "@phosphor-icons/react";
 
 const navItems: { href: string; label: string; icon: Icon; enabled: boolean }[] = [
-  { href: "/dashboard", label: "Home", icon: House, enabled: true },
   { href: "/dashboard/my", label: "My Page", icon: UserCircle, enabled: true },
-  { href: "/dashboard/household", label: "Household", icon: UsersThree, enabled: true },
   { href: "/dashboard/calendar", label: "Calendar", icon: CalendarDots, enabled: true },
   { href: "/dashboard/feed", label: "Feed", icon: Megaphone, enabled: true },
   { href: "/dashboard/votes", label: "Votes", icon: Scales, enabled: true },
@@ -27,10 +23,7 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   return (
     <nav className="space-y-1">
       {navItems.map((item) => {
-        const isActive =
-          item.href === "/dashboard"
-            ? pathname === "/dashboard"
-            : pathname.startsWith(item.href);
+        const isActive = pathname.startsWith(item.href);
 
         if (!item.enabled) {
           return (

--- a/src/components/dashboard/top-bar.test.tsx
+++ b/src/components/dashboard/top-bar.test.tsx
@@ -9,7 +9,6 @@ vi.mock("@/lib/auth/actions", () => ({
 }));
 
 const defaultProps = {
-  householdName: "Test Household",
   inviteCode: "ABC12345",
   userName: "Alice",
   avatarUrl: null as string | null,
@@ -17,11 +16,6 @@ const defaultProps = {
 };
 
 describe("TopBar", () => {
-  it("renders household name", () => {
-    render(<TopBar {...defaultProps} />);
-    expect(screen.getByText("Test Household")).toBeInTheDocument();
-  });
-
   it("renders user name", () => {
     render(<TopBar {...defaultProps} />);
     expect(screen.getByText("Alice")).toBeInTheDocument();

--- a/src/components/dashboard/top-bar.tsx
+++ b/src/components/dashboard/top-bar.tsx
@@ -7,7 +7,6 @@ import { Copy, Check, SignOut, List } from "@phosphor-icons/react";
 import { signOut } from "@/lib/auth/actions";
 
 interface TopBarProps {
-  householdName: string;
   inviteCode: string;
   userName: string;
   avatarUrl: string | null;
@@ -24,7 +23,6 @@ function getInitials(name: string): string {
 }
 
 export function TopBar({
-  householdName,
   inviteCode,
   userName,
   avatarUrl,
@@ -43,7 +41,7 @@ export function TopBar({
   };
 
   return (
-    <header className="h-16 border-b border-border-light bg-surface flex items-center justify-between px-4 lg:px-6">
+    <header className="h-16 border border-border-light bg-surface/70 backdrop-blur-md flex items-center justify-between px-4 lg:px-6 lg:rounded-2xl lg:mx-3 lg:mt-3 lg:shadow-lg">
       <div className="flex items-center gap-3">
         <button
           onClick={onMenuToggle}
@@ -52,9 +50,6 @@ export function TopBar({
         >
           <List className="w-5 h-5" />
         </button>
-        <h2 className="text-sm font-semibold text-text-primary hidden sm:block">
-          {householdName}
-        </h2>
       </div>
 
       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Changes

- **Glassmorphism UI**: Updated sidebar and top bar with `backdrop-blur-md` and semi-transparent backgrounds (`bg-surface/70`)
- **Sidebar improvements**:
  - Added rounded corners and shadow on desktop (`lg:rounded-2xl`, `lg:shadow-lg`)
  - Moved household name to sidebar header with handwritten font styling
  - Made household name a clickable link to `/dashboard/household`
  - Moved close button to header
  - Refined borders and spacing
- **Top bar enhancements**:
  - Applied matching glassmorphism effects
  - Removed household name from top bar (now in sidebar only)
  - Added rounded corners and shadow on desktop
- **Navigation cleanup**:
  - Removed "Home" and "Household" from sidebar nav items
  - Simplified active route detection logic
  - Updated tests to reflect navigation changes
- **Typography**: Added Patrick Hand font for handwritten-style text
- **Styling**: Updated CSS variables and refined border colors with opacity